### PR TITLE
TOPS-862 - mock s3 calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,33 @@
 # to-data-library
 Timeout Data Teams Official Data Library
 
+## Python packages
+
+- `setup.py` includes a list of the 3rd party packages required by the this package when distbuted.
+- `requirements.in` should include the packages in `setup.py` plus those required for dev/test.
+- `requirements.txt` is built from `requirements.in` using `pip-compile`.
+
 ## local dev and testing
 
 - Install timeout-tools
 
 ```
-$ pip install git+ssh://git@github.com/timeoutdigital/timeout-tools
+pip install git+ssh://git@github.com/timeoutdigital/timeout-tools
 ```
 
 - If you don't have pyenv/pyenv-virtual installed
 
 ```
-$ timeout-tools pyenv-install
+timeout-tools pyenv-install
 ```
 
-- setup the python environment
-```
-$ timeout-tools python-setup
-```
-
-- install this repo
+- clone this repo and setup python env
 
 ```
-$ pip install git+https://github.com/timeoutdigital/to-data-library.git@v.1.0.1
+timeout-tools ws to-data-library <ticket_num>
 ```
 
-- populate environment variables # TODO: change to auto populate
+- populate environment variables # TODO: mock tests so removing requirement for vars
 
 ```
 export PROJECT=to-data-platform-dev

--- a/requirements.in
+++ b/requirements.in
@@ -5,8 +5,10 @@ google-cloud-bigquery
 google-cloud-storage
 Jinja2
 markupsafe
+moto[s3]
 oauth2client
 paramiko
 parse
+pip-tools
 pre-commit
 pysftp

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,16 @@
 bcrypt==4.0.1
     # via paramiko
 boto3==1.26.144
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   moto
 botocore==1.29.144
     # via
     #   boto3
+    #   moto
     #   s3transfer
+build==0.10.0
+    # via pip-tools
 cachetools==5.3.1
     # via google-auth
 certifi==2023.5.7
@@ -24,8 +29,12 @@ cfgv==3.4.0
     # via pre-commit
 charset-normalizer==3.1.0
     # via requests
+click==8.1.7
+    # via pip-tools
 cryptography==41.0.0
-    # via paramiko
+    # via
+    #   moto
+    #   paramiko
 delegator-py==0.1.1
     # via -r requirements.in
 distlib==0.3.7
@@ -84,7 +93,9 @@ identify==2.5.27
 idna==3.4
     # via requests
 jinja2==3.1.2
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   moto
 jmespath==1.0.1
     # via
     #   boto3
@@ -93,12 +104,17 @@ markupsafe==2.1.2
     # via
     #   -r requirements.in
     #   jinja2
+    #   werkzeug
+moto[s3]==4.2.0
+    # via -r requirements.in
 nodeenv==1.8.0
     # via pre-commit
 oauth2client==4.1.3
     # via -r requirements.in
 packaging==23.1
-    # via google-cloud-bigquery
+    # via
+    #   build
+    #   google-cloud-bigquery
 paramiko==3.2.0
     # via
     #   -r requirements.in
@@ -107,6 +123,8 @@ parse==1.19.0
     # via -r requirements.in
 pexpect==4.8.0
     # via delegator-py
+pip-tools==7.3.0
+    # via -r requirements.in
 platformdirs==3.10.0
     # via virtualenv
 pre-commit==3.3.3
@@ -122,6 +140,8 @@ protobuf==4.23.2
     #   proto-plus
 ptyprocess==0.7.0
     # via pexpect
+py-partiql-parser==0.3.6
+    # via moto
 pyasn1==0.5.0
     # via
     #   oauth2client
@@ -137,19 +157,29 @@ pynacl==1.5.0
     # via paramiko
 pyparsing==3.0.9
     # via httplib2
+pyproject-hooks==1.0.0
+    # via build
 pysftp==0.2.9
     # via -r requirements.in
 python-dateutil==2.8.2
     # via
     #   botocore
     #   google-cloud-bigquery
+    #   moto
 pyyaml==6.0.1
-    # via pre-commit
+    # via
+    #   moto
+    #   pre-commit
+    #   responses
 requests==2.31.0
     # via
     #   google-api-core
     #   google-cloud-bigquery
     #   google-cloud-storage
+    #   moto
+    #   responses
+responses==0.23.3
+    # via moto
 rsa==4.9
     # via
     #   google-auth
@@ -162,6 +192,13 @@ six==1.16.0
     #   google-auth-httplib2
     #   oauth2client
     #   python-dateutil
+tomli==2.0.1
+    # via
+    #   build
+    #   pip-tools
+    #   pyproject-hooks
+types-pyyaml==6.0.12.11
+    # via responses
 typing-extensions==4.7.1
     # via filelock
 uritemplate==4.1.1
@@ -171,8 +208,16 @@ urllib3==1.26.16
     #   botocore
     #   google-auth
     #   requests
+    #   responses
 virtualenv==20.24.3
     # via pre-commit
+werkzeug==2.3.7
+    # via moto
+wheel==0.41.2
+    # via pip-tools
+xmltodict==0.13.0
+    # via moto
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,7 +1,6 @@
 import glob
 import os
 
-import boto3
 from google.cloud import bigquery, exceptions, storage
 
 
@@ -43,24 +42,6 @@ class Setup:
     def delete_bq_dataset(self):
         bigquery_client = bigquery.Client(project=self.project)
         bigquery_client.delete_dataset(self.dataset_id, delete_contents=True)
-
-    def upload_s3_files(self):
-        s3_client = boto3.resource(
-            service_name='s3',
-            region_name=self.s3_region
-        )
-        bucket = s3_client.Bucket(self.s3_bucket)
-        bucket.upload_file('tests/data/sample.csv', 'download_sample.csv')
-
-    def remove_s3_files(self):
-        s3_client = boto3.resource(service_name='s3',
-                                   region_name=self.s3_region,
-                                   aws_access_key_id=self.s3_access_key,
-                                   aws_secret_access_key=self.s3_secret_key)
-
-        s3_client.Bucket(self.s3_bucket).Object('download_sample.csv').delete()
-        s3_client.Bucket(self.s3_bucket).Object('sample.csv').delete()
-        s3_client.Bucket(self.s3_bucket).Object('s3_upload_file.csv').delete()
 
     def create_bucket(self):
         storage_client = storage.Client(project=self.project)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,10 +13,8 @@ class Setup:
         self.dataset_id = os.environ.get('DATASET_ID', None)
         self.table_id = os.environ.get('TABLE_ID', None)
         self.bucket_name = os.environ.get('BUCKET_NAME', None)
-        self.s3_region = os.environ.get('S3_REGION', None)
-        self.s3_access_key = os.environ.get('S3_ACCESS_KEY', None)
-        self.s3_secret_key = os.environ.get('S3_SECRET_KEY', None)
-        self.s3_bucket = os.environ.get('S3_BUCKET', None)
+        self.s3_region = 'eu-west-1'
+        self.s3_bucket = 'dummy-bucket'
 
     def create_bq_table(self):
         dataset_ref = bigquery.DatasetReference(project=self.project, dataset_id=self.dataset_id)
@@ -47,10 +45,10 @@ class Setup:
         bigquery_client.delete_dataset(self.dataset_id, delete_contents=True)
 
     def upload_s3_files(self):
-        s3_client = boto3.resource(service_name='s3',
-                                   region_name=self.s3_region,
-                                   aws_access_key_id=self.s3_access_key,
-                                   aws_secret_access_key=self.s3_secret_key)
+        s3_client = boto3.resource(
+            service_name='s3',
+            region_name=self.s3_region
+        )
         bucket = s3_client.Bucket(self.s3_bucket)
         bucket.upload_file('tests/data/sample.csv', 'download_sample.csv')
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -2,48 +2,53 @@ import os
 import unittest
 
 import boto3
+from moto import mock_s3
 
 from tests.setup import setup
 from to_data_library.data.s3 import Client
 
 
-def setUpModule():
-    setup.upload_s3_files()
-
-
-def tearDownModule():
-    setup.remove_s3_files()
-    setup.cleanup()
-
-
+@mock_s3
 class TestS3(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super(TestS3, self).__init__(*args, **kwargs)
         self.setup = setup
 
-    def test_download(self):
-        test_client = Client(f'{self.setup.s3_region}:{self.setup.s3_access_key}:{self.setup.s3_secret_key}')
+    def setUp(self):
+        s3 = boto3.resource("s3", region_name=self.setup.s3_region)
+        bucket = s3.Bucket(self.setup.s3_bucket)
+        bucket.create(CreateBucketConfiguration={
+                'LocationConstraint': self.setup.s3_region,
+            },
+        )
+        content = b"dummy-content"
+        key = 'download_sample.csv'
+        object = s3.Object(self.setup.s3_bucket, key)
+        object.put(Body=content)
 
-        test_client.download(setup.s3_bucket,
+    def test_download(self):
+        test_client = Client(self.setup.s3_region)
+
+        test_client.download(self.setup.s3_bucket,
                              'download_sample.csv')
         self.assertTrue(os.path.exists('download_sample.csv'))
 
-        test_client.download(setup.s3_bucket,
+        test_client.download(self.setup.s3_bucket,
                              'download_sample.csv',
                              'download_s3_sample.csv')
 
         self.assertTrue(os.path.exists('download_s3_sample.csv'))
 
     def test_upload(self):
-        test_client = Client(f'{self.setup.s3_region}:{self.setup.s3_access_key}:{self.setup.s3_secret_key}')
+        test_client = Client(self.setup.s3_region)
 
         test_client.upload('tests/data/sample.csv',
-                           setup.s3_bucket)
-        s3_client = boto3.resource(service_name='s3',
-                                   region_name=self.setup.s3_region,
-                                   aws_access_key_id=self.setup.s3_access_key,
-                                   aws_secret_access_key=self.setup.s3_secret_key)
+                           self.setup.s3_bucket)
+        s3_client = boto3.resource(
+            service_name='s3',
+            region_name=self.setup.s3_region
+        )
         bucket = s3_client.Bucket(setup.s3_bucket)
         obj = list(bucket.objects.filter(Prefix='sample.csv'))
         self.assertTrue(any(w.key == 'sample.csv' for w in obj))
@@ -51,10 +56,10 @@ class TestS3(unittest.TestCase):
         test_client.upload('tests/data/sample.csv',
                            setup.s3_bucket,
                            's3_upload_file.csv')
-        s3_client = boto3.resource(service_name='s3',
-                                   region_name=self.setup.s3_region,
-                                   aws_access_key_id=self.setup.s3_access_key,
-                                   aws_secret_access_key=self.setup.s3_secret_key)
+        s3_client = boto3.resource(
+            service_name='s3',
+            region_name=self.setup.s3_region
+        )
         bucket = s3_client.Bucket(setup.s3_bucket)
         obj = list(bucket.objects.filter(Prefix='s3_upload_file.csv'))
         self.assertTrue(any(w.key == 's3_upload_file.csv' for w in obj))

--- a/to_data_library/data/s3.py
+++ b/to_data_library/data/s3.py
@@ -3,7 +3,6 @@ import sys
 
 import boto3
 import botocore
-import parse
 
 from to_data_library.data import logs
 
@@ -17,12 +16,11 @@ class Client:
                                      {region}:{access_key}:{secret_key}
     """
 
-    def __init__(self, connection_string):
-        parsed_connection = parse.parse('{region}:{access_key}:{secret_key}', connection_string)
-        self.s3_client = boto3.resource(service_name='s3',
-                                        region_name=parsed_connection['region'],
-                                        aws_access_key_id=parsed_connection['access_key'],
-                                        aws_secret_access_key=parsed_connection['secret_key'])
+    def __init__(self, region):
+        self.s3_client = boto3.resource(
+            service_name='s3',
+            region_name=region
+        )
 
     def download(self, bucket_name, object_name, local_path='.'):
         """

--- a/to_data_library/data/s3.py
+++ b/to_data_library/data/s3.py
@@ -12,8 +12,7 @@ class Client:
         Client to s3 Storage functionality.
 
         Args:
-            connection_string (str): The S3 connection string in the format
-                                     {region}:{access_key}:{secret_key}
+            region (str): The AWS region
     """
 
     def __init__(self, region):
@@ -34,7 +33,7 @@ class Client:
 
         Example:
             >>> from to_data_library.data import s3
-            >>> client = s3.Client('region:access_key:secret_key')
+            >>> client = s3.Client('region')
             >>> client.download(bucket_name='my-s3-bucket-name',
             >>>                 object_name='folder-name/object-name',
             >>>                 local_path='/my-local/folder/file.csv')
@@ -64,7 +63,7 @@ class Client:
 
         Example:
             >>> from to_data_library.data import s3
-            >>> client = s3.Client('region:access_key:secret_key')
+            >>> client = s3.Client('region')
             >>> client.upload(local_path='/my-local/folder/file.csv',
             >>>               bucket_name='my-s3-bucket-name',
             >>>               object_name='object-name')
@@ -90,7 +89,7 @@ class Client:
 
         Example:
             >>> from to_data_library.data import s3
-            >>> client = s3.Client('region:access_key:secret_key')
+            >>> client = s3.Client('region')
             >>> client.list_files(bucket_name='s3-bucket-name', path='/path/inside/bucket/')
         """
 


### PR DESCRIPTION
unittests shouldn't call real resources

also drops the use of AWS access key, AWS auth will be picked up from the environment AWS profile/role

tests will fail as test_transfer test_bq still aren't mocked, I'll force merge this PR