### PR TITLE
DSS-3165

### DIFF
--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -105,3 +105,139 @@ def test_gs_to_bq(self, mock_default, mock_loadjobconfig,
         res = client._get_keys_in_s3_bucket(mock_aws_session, 'fake_bucket_name', 'fake_prefix_name')
 
         self.assertEqual(res, [])
+
+    def test_gs_to_bq_schema_validation(self):
+        client = transfer.Client('fake_project_name')
+        valid_schema = [('field1', 'STRING'), ('field2', 'INTEGER')]
+        with patch('google.cloud.bigquery.Client'), \
+             patch('google.cloud.bigquery.DatasetReference'), \
+             patch('google.cloud.bigquery.TableReference'), \
+             patch('google.cloud.bigquery.LoadJobConfig'):
+            # Should not raise
+            client.gs_to_bq(
+                gs_uris="gs://bucket/file.csv",
+                table="p.d.t",
+                write_preference="truncate",
+                schema=valid_schema
+            )
+            # Invalid schema: wrong type
+            with self.assertRaises(ValueError):
+                client.gs_to_bq(
+                    gs_uris="gs://bucket/file.csv",
+                    table="p.d.t",
+                    write_preference="truncate",
+                    schema=[('field1', 'NOTATYPE')]
+                )
+
+    def test_ftp_to_bq_schema_validation(self):
+        client = transfer.Client('fake_project_name')
+        valid_schema = [('field1', 'STRING')]
+        with patch('to_data_library.data.ftp.Client') as mock_ftp, \
+             patch('to_data_library.data.bq.Client') as mock_bq:
+            mock_ftp.return_value.download_file.return_value = '/tmp/file.csv'
+            mock_bq.return_value.upload_table.return_value = None
+            # Should not raise
+            client.ftp_to_bq(
+                ftp_connection_string='user:pass@host:21',
+                ftp_filepath='/file.csv',
+                bq_table='p.d.t',
+                write_preference='truncate',
+                bq_table_schema=valid_schema
+            )
+            # Invalid schema
+            with self.assertRaises(ValueError):
+                client.ftp_to_bq(
+                    ftp_connection_string='user:pass@host:21',
+                    ftp_filepath='/file.csv',
+                    bq_table='p.d.t',
+                    write_preference='truncate',
+                    bq_table_schema=[('field1', 'NOTATYPE')]
+                )
+
+    def test_gs_parquet_to_bq_schema_validation(self):
+        client = transfer.Client('fake_project_name')
+        valid_schema = [('field1', 'STRING')]
+        with patch('google.cloud.bigquery.Client'), \
+             patch('google.cloud.bigquery.DatasetReference'), \
+             patch('google.cloud.bigquery.TableReference'), \
+             patch('google.cloud.bigquery.LoadJobConfig'):
+            # Should not raise
+            client.gs_parquet_to_bq(
+                gs_uris="gs://bucket/file.parquet",
+                table="p.d.t",
+                write_preference="truncate",
+                schema=valid_schema
+            )
+            # Invalid schema: wrong type
+            with self.assertRaises(ValueError):
+                client.gs_parquet_to_bq(
+                    gs_uris="gs://bucket/file.parquet",
+                    table="p.d.t",
+                    write_preference="truncate",
+                    schema=[('field1', 'NOTATYPE')]
+                )
+
+    def test_s3_to_bq_schema_validation(self):
+        client = transfer.Client('fake_project_name')
+        valid_schema = [('field1', 'STRING')]
+        with patch('to_data_library.data.s3.Client') as mock_s3, \
+             patch('to_data_library.data.bq.Client') as mock_bq:
+            mock_s3.return_value.download.return_value = '/tmp/file.csv'
+            mock_bq.return_value.create_dataset.return_value = None
+            mock_bq.return_value.load_table_from_uris.return_value = None
+            # Should not raise
+            client.s3_to_bq(
+                aws_session=Mock(),
+                bucket_name='bucket',
+                object_name='file.csv',
+                bq_table='p.d.t',
+                write_preference='truncate',
+                schema=valid_schema
+            )
+            # Invalid schema
+            with self.assertRaises(ValueError):
+                client.s3_to_bq(
+                    aws_session=Mock(),
+                    bucket_name='bucket',
+                    object_name='file.csv',
+                    bq_table='p.d.t',
+                    write_preference='truncate',
+                    schema=[('field1', 'NOTATYPE')]
+                )
+
+    def test_s3_to_bq_partitioning_and_config(self):
+        client = transfer.Client('fake_project_name')
+        valid_schema = [('field1', 'STRING')]
+        with patch('to_data_library.data.s3.Client') as mock_s3, \
+             patch('to_data_library.data.bq.Client') as mock_bq, \
+             patch('os.remove') as mock_remove, \
+             patch('os.path.exists', return_value=True):
+            mock_s3.return_value.download.return_value = '/tmp/file.csv'
+            mock_bq.return_value.create_dataset.return_value = None
+            mock_bq.return_value.load_table_from_uris.return_value = None
+
+            # Test with partition_date and partition_field, custom delimiter, source_format, max_bad_records
+            client.s3_to_bq(
+                aws_session=Mock(),
+                bucket_name='bucket',
+                object_name='file.csv',
+                bq_table='p.d.t',
+                write_preference='truncate',
+                schema=valid_schema,
+                partition_date='20240101',
+                partition_field='field1',
+                source_format='CSV',
+                separator='|',
+                max_bad_records=5
+            )
+
+            # Check that os.remove was called for cleanup
+            mock_remove.assert_called_once_with('/tmp/file.csv')
+            # Check that load_table_from_uris was called (table_id should have $20240101)
+            args, kwargs = mock_bq.return_value.load_table_from_uris.call_args
+            self.assertIn('$20240101', str(args[1].table_id))
+            # Check job_config attributes
+            job_config = kwargs['job_config']
+            self.assertEqual(job_config.source_format, 'CSV')
+            self.assertEqual(job_config.field_delimiter, '|')
+            self.assertEqual(job_config.max_bad_records, 5)

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -285,12 +285,14 @@ class Client:
                                               ``'truncate'``: Erases all existing data in a table before writing the
                                                 new data.
             ftp_filepath (str): The path to the file to download.
-            separator (:obj:`str`, Optional): The separator. Defaults to :data:`,`.\n            skip_leading_rows (boolean, Optional):  True to skip the first row of the file otherwise False. Defaults to
-              :data:`True`.
+            separator (:obj:`str`, Optional): The separator. Defaults to :data:`,`.\n            
+            skip_leading_rows (boolean, Optional): True to skip the first row of the file otherwise False. 
+                Defaults to :data:`True`.
             bq_table_schema (tuple, Optional): The BigQuery table schema. For example: ``(('first_field','STRING'),
             ('second_field','STRING'))``
-            partition_date (str, Optional): The ingestion date for partitioned BigQuery table. For example: ``20210101``
-            . The partition field name will be __PARTITIONTIME
+            partition_date (str, Optional): The ingestion date for partitioned BigQuery table. 
+                For example: ``20210101``. 
+            The partition field name will be __PARTITIONTIME
 
         Examples:
             >>> from to_data_library.data import transfer
@@ -331,8 +333,9 @@ class Client:
             bq_table (str): The BigQuery table. For example: ``my-project-id.my-dataset.my-table``
             ftp_connection_string (str): The FTP connection string in the format {username}:{password}@{host}:{port}
             ftp_filepath (str): The path to the file to download.
-            separator (:obj:`str`, optional): The separator. Defaults to :data:`,`.\n            print_header (boolean, Optional):  True to write header for the CSV file, otherwise False. Defaults to :
-            data:`True`.
+            separator (:obj:`str`, optional): The separator. Defaults to :data:`,`.\n            
+            print_header (boolean, Optional):  True to write header for the CSV file, otherwise False. 
+            Defaults to : data:`True`.
 
         Examples:
             >>> from to_data_library.data import transfer
@@ -510,9 +513,11 @@ class Client:
           separator (str, optional): The separator. Defaults to `,`.
           skip_leading_rows (boolean, Optional):  True to skip the first row of the file otherwise False. Defaults to
             `True`.
-          schema (tuple, optional): The BigQuery table schema. For example: ``(('first_field','STRING'),('second_field', 'STRING'))``
+          schema (tuple, optional): The BigQuery table schema. For example: ``(('first_field','STRING'),
+          ('second_field', 'STRING'))``
           partition_date (str, Optional): The ingestion date for partitioned BigQuery table. For example: ``20210101``.
-          partition_field (str, Optional): The field on which the destination table is partitioned. The field must be a top-level TIMESTAMP or DATE field. Must be used in conjunction with partition_date.
+          partition_field (str, Optional): The field on which the destination table is partitioned. 
+          The field must be a top-level TIMESTAMP or DATE field. Must be used in conjunction with partition_date.
           source_format (str, Optional): The file format (CSV, JSON, PARQUET or AVRO). Defaults to 'CSV'.
           max_bad_records (int, Optional): The maximum number of rows with errors. Defaults to 0.
 

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -285,13 +285,13 @@ class Client:
                                               ``'truncate'``: Erases all existing data in a table before writing the
                                                 new data.
             ftp_filepath (str): The path to the file to download.
-            separator (:obj:`str`, Optional): The separator. Defaults to :data:`,`.\n            
-            skip_leading_rows (boolean, Optional): True to skip the first row of the file otherwise False. 
+            separator (:obj:`str`, Optional): The separator. Defaults to :data:`,`.\n
+            skip_leading_rows (boolean, Optional): True to skip the first row of the file otherwise False.
                 Defaults to :data:`True`.
             bq_table_schema (tuple, Optional): The BigQuery table schema. For example: ``(('first_field','STRING'),
             ('second_field','STRING'))``
-            partition_date (str, Optional): The ingestion date for partitioned BigQuery table. 
-                For example: ``20210101``. 
+            partition_date (str, Optional): The ingestion date for partitioned BigQuery table.
+                For example: ``20210101``.
             The partition field name will be __PARTITIONTIME
 
         Examples:
@@ -333,8 +333,8 @@ class Client:
             bq_table (str): The BigQuery table. For example: ``my-project-id.my-dataset.my-table``
             ftp_connection_string (str): The FTP connection string in the format {username}:{password}@{host}:{port}
             ftp_filepath (str): The path to the file to download.
-            separator (:obj:`str`, optional): The separator. Defaults to :data:`,`.\n            
-            print_header (boolean, Optional):  True to write header for the CSV file, otherwise False. 
+            separator (:obj:`str`, optional): The separator. Defaults to :data:`,`.\n
+            print_header (boolean, Optional):  True to write header for the CSV file, otherwise False.
             Defaults to : data:`True`.
 
         Examples:
@@ -516,7 +516,7 @@ class Client:
           schema (tuple, optional): The BigQuery table schema. For example: ``(('first_field','STRING'),
           ('second_field', 'STRING'))``
           partition_date (str, Optional): The ingestion date for partitioned BigQuery table. For example: ``20210101``.
-          partition_field (str, Optional): The field on which the destination table is partitioned. 
+          partition_field (str, Optional): The field on which the destination table is partitioned.
           The field must be a top-level TIMESTAMP or DATE field. Must be used in conjunction with partition_date.
           source_format (str, Optional): The file format (CSV, JSON, PARQUET or AVRO). Defaults to 'CSV'.
           max_bad_records (int, Optional): The maximum number of rows with errors. Defaults to 0.

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -484,7 +484,7 @@ class Client:
         pages = paginator.paginate(Bucket=bucket_name, Prefix=prefix_name)
         for page in pages:
             print(f"page: {page}")
-            for obj in page['Contents']:
+            for obj in page.get('Contents', []):
                 key = obj['Key']
                 if not key.endswith('/') and re.match(regex, key):
                     s3_files.append(obj.get('Key'))

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -24,15 +24,22 @@ class Client:
 
     @staticmethod
     def validate_schema(schema):
-        VALID_BQ_TYPES = {"STRING", "BYTES", "INTEGER", "INT64", "FLOAT", "FLOAT64", "NUMERIC", "BIGNUMERIC", "BOOLEAN", "BOOL", "TIMESTAMP", "DATE", "TIME", "DATETIME", "GEOGRAPHY", "RECORD", "STRUCT"}
+        VALID_BQ_TYPES = {
+            "STRING", "BYTES", "INTEGER", "INT64", "FLOAT", "FLOAT64", "NUMERIC", "BIGNUMERIC",
+            "BOOLEAN", "BOOL", "TIMESTAMP", "DATE", "TIME", "DATETIME", "GEOGRAPHY", "RECORD", "STRUCT"
+        }
         for field in schema:
             if not isinstance(field, (list, tuple)) or len(field) < 2:
-                raise ValueError(f"Schema field {field} is not a tuple of (name, type)")
+                raise ValueError(
+                    f"Schema field {field} is not a tuple of (name, type)"
+                )
             name, type_ = field[0], field[1]
             if not isinstance(name, str):
                 raise ValueError(f"Field name {name} is not a string")
             if type_.upper() not in VALID_BQ_TYPES:
-                raise ValueError(f"Field type {type_} is not a valid BigQuery type")
+                raise ValueError(
+                    f"Field type {type_} is not a valid BigQuery type"
+                )
 
     def bq_to_gs(self, table, bucket_name, separator=',', print_header=True, compress=False):
         """Extract BigQuery table into the GoogleStorage
@@ -61,8 +68,9 @@ class Client:
         table_ref = bigquery.TableReference(dataset_ref, table_id=table_id)
 
         bq_client = bigquery.Client(project=self.project)
-        logs.client.logger.info('Extracting from {table} to gs://{bucket_name}/{table_id}_*'.format(
-            bucket_name=bucket_name, table_id=table_id, table=table)
+        logs.client.logger.info(
+            'Extracting from {table} to gs://{bucket_name}/{table_id}_*'.format(
+                bucket_name=bucket_name, table_id=table_id, table=table)
         )
         extract_job = bq_client.extract_table(
             source=table_ref,
@@ -143,14 +151,16 @@ class Client:
             job_config.skip_leading_rows = 1
 
         if (partition_date and not partition_field):
-            job_config.time_partitioning = bigquery.TimePartitioning(type_=bigquery.TimePartitioningType.DAY)
+            job_config.time_partitioning = bigquery.TimePartitioning(
+                type_=bigquery.TimePartitioningType.DAY)
             table_id += '${}'.format(partition_date)
         elif (partition_date and partition_field):
             job_config.time_partitioning = bigquery.TimePartitioning(
                 type_=bigquery.TimePartitioningType.DAY, field=partition_field)
             table_id += '${}'.format(partition_date)
         elif (partition_field and not partition_date and write_preference == 'truncate'):
-            logs.client.logger.error("Error if partition_field is supplied partitioned_date must also be supplied")
+            logs.client.logger.error(
+                "Error if partition_field is supplied partitioned_date must also be supplied")
             sys.exit(1)
 
         table_ref = bigquery.TableReference(dataset_ref, table_id=table_id)
@@ -168,7 +178,8 @@ class Client:
         elif source_format == 'PARQUET':
             job_config.source_format = bigquery.SourceFormat.PARQUET
         else:
-            logs.client.logger.error(f"Invalid SourceFormat entered: {source_format}")
+            logs.client.logger.error(
+                f"Invalid SourceFormat entered: {source_format}")
             sys.exit(1)
 
         if schema:
@@ -290,8 +301,7 @@ class Client:
                                               ``'truncate'``: Erases all existing data in a table before writing the
                                                 new data.
             ftp_filepath (str): The path to the file to download.
-            separator (:obj:`str`, Optional): The separator. Defaults to :data:`,`.
-            skip_leading_rows (boolean, Optional):  True to skip the first row of the file otherwise False. Defaults to
+            separator (:obj:`str`, Optional): The separator. Defaults to :data:`,`.\n            skip_leading_rows (boolean, Optional):  True to skip the first row of the file otherwise False. Defaults to
               :data:`True`.
             bq_table_schema (tuple, Optional): The BigQuery table schema. For example: ``(('first_field','STRING'),
             ('second_field','STRING'))``
@@ -337,8 +347,7 @@ class Client:
             bq_table (str): The BigQuery table. For example: ``my-project-id.my-dataset.my-table``
             ftp_connection_string (str): The FTP connection string in the format {username}:{password}@{host}:{port}
             ftp_filepath (str): The path to the file to download.
-            separator (:obj:`str`, optional): The separator. Defaults to :data:`,`.
-            print_header (boolean, Optional):  True to write header for the CSV file, otherwise False. Defaults to :
+            separator (:obj:`str`, optional): The separator. Defaults to :data:`,`.\n            print_header (boolean, Optional):  True to write header for the CSV file, otherwise False. Defaults to :
             data:`True`.
 
         Examples:
@@ -430,10 +439,11 @@ class Client:
         if not wildcard:
             wildcard = '.*'
 
-        s3_files = self._get_keys_in_s3_bucket(aws_session=aws_session,
-                                               bucket_name=s3_bucket_name,
-                                               prefix_name=s3_object_name,
-                                               wildcard=wildcard)
+        s3_files = self._get_keys_in_s3_bucket(
+            aws_session=aws_session,
+            bucket_name=s3_bucket_name,
+            prefix_name=s3_object_name,
+            wildcard=wildcard)
 
         logs.client.logger.info(f'Found {str(s3_files)} files in S3')
 
@@ -455,9 +465,11 @@ class Client:
             # Try to upload file from local to GCS.
             try:
                 gs_client.upload(local_file, gs_bucket_name, gs_file_name)
-                logs.client.logger.info(f'Successfully uploaded {local_file} to {gs_bucket_name}/{gs_file_name}')
+                logs.client.logger.info(
+                    f'Successfully uploaded {local_file} to {gs_bucket_name}/{gs_file_name}')
             except Exception as e:
-                logs.client.logger.error(f"Failed to upload {local_file} to {gs_bucket_name}/{gs_file_name}: {e}")
+                logs.client.logger.error(
+                    f"Failed to upload {local_file} to {gs_bucket_name}/{gs_file_name}: {e}")
             finally:
                 if os.path.exists(local_file):
                     os.remove(local_file)
@@ -549,13 +561,16 @@ class Client:
 
         # Partitioning logic (same as gs_to_bq)
         if partition_date and not partition_field:
-            job_config.time_partitioning = bigquery.TimePartitioning(type_=bigquery.TimePartitioningType.DAY)
+            job_config.time_partitioning = bigquery.TimePartitioning(
+                type_=bigquery.TimePartitioningType.DAY)
             table_id += f'${partition_date}'
         elif partition_date and partition_field:
-            job_config.time_partitioning = bigquery.TimePartitioning(type_=bigquery.TimePartitioningType.DAY, field=partition_field)
+            job_config.time_partitioning = bigquery.TimePartitioning(
+                type_=bigquery.TimePartitioningType.DAY, field=partition_field)
             table_id += f'${partition_date}'
         elif partition_field and not partition_date and write_preference == 'truncate':
-            logs.client.logger.error("Error: if partition_field is supplied, partition_date must also be supplied")
+            logs.client.logger.error(
+                "Error: if partition_field is supplied, partition_date must also be supplied")
             sys.exit(1)
 
         table_ref = bigquery.TableReference(dataset_ref, table_id=table_id)
@@ -573,7 +588,8 @@ class Client:
         elif source_format == 'PARQUET':
             job_config.source_format = bigquery.SourceFormat.PARQUET
         else:
-            logs.client.logger.error(f"Invalid SourceFormat entered: {source_format}")
+            logs.client.logger.error(
+                f"Invalid SourceFormat entered: {source_format}")
             sys.exit(1)
 
         # Schema as tuple/list of tuples

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -168,6 +168,10 @@ class Client:
         if separator:
             job_config.field_delimiter = separator
 
+        if schema:
+            self.validate_schema(schema)
+            job_config.schema = [bigquery.SchemaField(field[0], field[1]) for field in schema]
+
         # Define the source format
         if source_format == 'CSV':
             job_config.source_format = bigquery.SourceFormat.CSV
@@ -180,26 +184,6 @@ class Client:
         else:
             logs.client.logger.error(
                 f"Invalid SourceFormat entered: {source_format}")
-            sys.exit(1)
-
-        if schema:
-            self.validate_schema(schema)
-            job_config.schema = [bigquery.SchemaField(field[0], field[1]) for field in schema]
-
-        if separator:
-            job_config.field_delimiter = separator
-
-        # Define the source format
-        if source_format == 'CSV':
-            job_config.source_format = bigquery.SourceFormat.CSV
-        elif source_format == 'JSON':
-            job_config.source_format = bigquery.SourceFormat.NEWLINE_DELIMITED_JSON
-        elif source_format == 'AVRO':
-            job_config.source_format = bigquery.SourceFormat.AVRO
-        elif source_format == 'PARQUET':
-            job_config.source_format = bigquery.SourceFormat.PARQUET
-        else:
-            logs.client.logger.error(f"Invalid SourceFormat entered: {source_format}")
             sys.exit(1)
 
         bq_client = bq.Client(project,


### PR DESCRIPTION
For this ticket: https://timeoutgroup.atlassian.net/browse/DSS-3165?atlOrigin=eyJpIjoiNzc1OGI1OWJiODljNDA1YzlkMGVkMjlkMDRlMGQyMzgiLCJwIjoiaiJ9 I have looked into updating to-data-library to include a process for uploading files from s3 to big query, however, when looking into the library I found the method already exists as well as a method to transfer files from s3 to gcs.

I tested using the methods in an existing splash da and found the way partitioning was defined was not compatible with our code so I have made changes to correct this and keep the code similar to the gs_to_bq method (which I have used before).

I also have added some schema validation and tests. I would be interested to know if you think we need more schema validation and if some of the tests are too repetitive.
Also do you think the schema structure is sufficient? I have tried to look at the data for the ads reporting but not sure I'm looking in the right place.