### PR TITLE
DSS-3231 Add schema_update_options to gs_to_bq transfer method

### DIFF
--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -44,6 +44,7 @@ class TestTransfer(unittest.TestCase):
         mock_loadjobconfig.return_value.write_disposition = 'WRITE_TRUNCATE'
         mock_loadjobconfig.return_value.allow_quoted_newlines = True
         mock_loadjobconfig.return_value.max_bad_records = 10
+        mock_loadjobconfig.return_value.schema_update_options = ['ALLOW_FIELD_ADDITION']
 
         # Mock load_table_from_uris on the bq.Client
         mock_bq_client.return_value.load_table_from_uris = Mock()
@@ -53,7 +54,8 @@ class TestTransfer(unittest.TestCase):
             gs_uris="gs://{}/{}".format('fake_bucket_name', 'sample.csv'),
             table='{}.{}.{}'.format('fake_project_name', 'fake_dataset_id', 'fake_table_id'),
             write_preference='truncate',
-            max_bad_records=10
+            max_bad_records=10,
+            schema_update_options=['ALLOW_FIELD_ADDITION']
         )
 
         mock_datasetreference.assert_called_with(project='fake_project_name', dataset_id='fake_dataset_id')
@@ -71,6 +73,7 @@ class TestTransfer(unittest.TestCase):
         self.assertEqual(job_config.write_disposition, 'WRITE_TRUNCATE')
         self.assertEqual(job_config.allow_quoted_newlines, True)
         self.assertEqual(job_config.max_bad_records, 10)
+        self.assertEqual(job_config.schema_update_options, ['ALLOW_FIELD_ADDITION'])
 
         # Assert load_table_from_uris is called with the right parameters
         mock_bq_client.return_value.load_table_from_uris.assert_called_once_with(

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -77,7 +77,9 @@ class Client:
                  schema: List[bigquery.SchemaField] = None,
                  partition_date: str = None,
                  partition_field: str = None,
-                 max_bad_records: int = 0):
+                 max_bad_records: int = 0,
+                 schema_update_options: List[bigquery.SchemaUpdateOption] = None
+                 ):
         """Load file from Google Storage into the BigQuery table
 
         Args:
@@ -107,6 +109,8 @@ class Client:
               Here partitioned_date will be used to update or alter the table using the partition
             schema (List[bigquery.SchemaField], Optional): A List of SchemaFields.
             max_bad_records (int, Optional): The maximum number of rows with errors. Defaults to :data:0
+            schema_update_options (List[bigquery.SchemaUpdateOption], Optional): A List of SchemaUpdateOptions.
+                How to update the schema when performing load/extract operations.
 
         Examples:
             >>> from to_data_library.data import transfer
@@ -121,7 +125,8 @@ class Client:
             autodetect=auto_detect,
             write_disposition=get_bq_write_disposition(write_preference),
             allow_quoted_newlines=True,
-            max_bad_records=max_bad_records
+            max_bad_records=max_bad_records,
+            schema_update_options=schema_update_options
         )
 
         if skip_leading_rows:


### PR DESCRIPTION
This allows us to use the option to automatically add columns if new columns appear in the data. For example, if we update a schema file to include a new field, we can now set the column to add automatically (as NULLABLE) without having to manually add columns in dev, staging and prod separately.

See tests/checks here:

1. This uses the da-cms-data-ingestion pipeline to test using the new transfer config option: [[LINK](https://timeoutgroup.atlassian.net/browse/DSS-3231?focusedCommentId=262940)]

2. I've added the new option to the gs_to_bq test and checked that the tests still pass:
<img width="971" height="439" alt="image" src="https://github.com/user-attachments/assets/2391f5fd-1d32-4b16-a091-ba720d6fd271" />

<img width="1914" height="912" alt="image" src="https://github.com/user-attachments/assets/6fdbe2a0-d4b3-4573-ab05-8d5c6c560883" />

