### PR TITLE
DSS-3231 Add success return to gs_to_bq transfer method

### DIFF
--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -44,6 +44,7 @@ class TestTransfer(unittest.TestCase):
         mock_loadjobconfig.return_value.write_disposition = 'WRITE_TRUNCATE'
         mock_loadjobconfig.return_value.allow_quoted_newlines = True
         mock_loadjobconfig.return_value.max_bad_records = 10
+        mock_loadjobconfig.return_value.schema_update_options = ['ALLOW_FIELD_ADDITION']
 
         # Mock load_table_from_uris on the bq.Client
         mock_bq_client.return_value.load_table_from_uris = Mock()
@@ -53,7 +54,8 @@ class TestTransfer(unittest.TestCase):
             gs_uris="gs://{}/{}".format('fake_bucket_name', 'sample.csv'),
             table='{}.{}.{}'.format('fake_project_name', 'fake_dataset_id', 'fake_table_id'),
             write_preference='truncate',
-            max_bad_records=10
+            max_bad_records=10,
+            schema_update_options=['ALLOW_FIELD_ADDITION']
         )
 
         mock_datasetreference.assert_called_with(project='fake_project_name', dataset_id='fake_dataset_id')
@@ -71,6 +73,7 @@ class TestTransfer(unittest.TestCase):
         self.assertEqual(job_config.write_disposition, 'WRITE_TRUNCATE')
         self.assertEqual(job_config.allow_quoted_newlines, True)
         self.assertEqual(job_config.max_bad_records, 10)
+        self.assertEqual(job_config.schema_update_options, ['ALLOW_FIELD_ADDITION'])
 
         # Assert load_table_from_uris is called with the right parameters
         mock_bq_client.return_value.load_table_from_uris.assert_called_once_with(

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -183,7 +183,7 @@ class Client:
 
         try:
             # Start the load job
-            bq_client.load_table_from_uris(
+            return bq_client.load_table_from_uris(
                 gs_uris, table_ref, job_config=job_config
             )
 

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -77,7 +77,9 @@ class Client:
                  schema: List[bigquery.SchemaField] = None,
                  partition_date: str = None,
                  partition_field: str = None,
-                 max_bad_records: int = 0):
+                 max_bad_records: int = 0,
+                 schema_update_options: List[bigquery.SchemaUpdateOption] = None
+                 ):
         """Load file from Google Storage into the BigQuery table
 
         Args:
@@ -107,6 +109,8 @@ class Client:
               Here partitioned_date will be used to update or alter the table using the partition
             schema (List[bigquery.SchemaField], Optional): A List of SchemaFields.
             max_bad_records (int, Optional): The maximum number of rows with errors. Defaults to :data:0
+            schema_update_options (List[bigquery.SchemaUpdateOption], Optional): A List of SchemaUpdateOptions.
+                How to update the schema when performing load/extract operations.
 
         Examples:
             >>> from to_data_library.data import transfer
@@ -121,7 +125,8 @@ class Client:
             autodetect=auto_detect,
             write_disposition=get_bq_write_disposition(write_preference),
             allow_quoted_newlines=True,
-            max_bad_records=max_bad_records
+            max_bad_records=max_bad_records,
+            schema_update_options=schema_update_options
         )
 
         if skip_leading_rows:


### PR DESCRIPTION
This is because it can cause silent failures without it. There is a try-except (without a 'raise') within the load_table_from_uris method, so if there is an error in the BigQuery load job, the try-except causes it to appear as a success. Hence we can't then ascertain whether the job failed and raise an error accordingly.

See JIRA ticket comment [here](https://timeoutgroup.atlassian.net/browse/DSS-3231?focusedCommentId=263012) for local testing of this method (using a copy of the transfer module)