### PR TITLE
DSS-3346 Rewrite s3_to_gs and gs_to_bq to use new GCS file structure

### DIFF
--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1,8 +1,5 @@
-import os
-import tempfile
 import unittest
-import unittest.mock
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import Mock, patch
 
 import pandas as pd
 
@@ -11,6 +8,7 @@ from to_data_library.data import transfer
 
 
 class TestTransfer(unittest.TestCase):
+
     @patch('google.cloud.bigquery.Client')
     @patch("to_data_library.data.gs.storage.Client")
     def test_bq_to_gs(self, mock_storage, mock_bigquery):
@@ -30,79 +28,135 @@ class TestTransfer(unittest.TestCase):
 
         mock_storage_client.list_blobs.assert_called_once_with('fake_bucket_name')
 
-    @patch('google.cloud.bigquery.DatasetReference')
-    @patch('google.cloud.bigquery.TableReference')
+    def test_build_gs_bucket_name(self):
+        client = transfer.Client(project='fake_project')
+        bucket_name = client.build_gs_bucket_name(
+            business_type='fake_business_type',
+            source_type='fake_sales_type'
+        )
+        expected_bucket_name = '-'.join(['fake_project', 'fake_business_type', 'fake_sales_type'])
+        self.assertEqual(bucket_name, expected_bucket_name)
+
+    def test_build_gs_prefix(self):
+        client = transfer.Client(project='fake_project')
+        prefix = client.build_gs_prefix(
+            source='fake-source',
+            ingestion_type='batch',
+            etl_datetime_utc='2024-01-01T00:00:00Z',
+            data_date='2024-01-01'
+        )
+        expected_prefix = 'fake-source/batch/2024-01-01/2024-01-01T00:00:00Z'
+        self.assertEqual(prefix, expected_prefix)
+
+    def test_build_gs_file_name(self):
+        client = transfer.Client(project='fake_project')
+        file_name = client.build_gs_file_name(
+            source='fake-source',
+            dimension='fake-dimension',
+            etl_datetime_utc='2024-01-01T00:00:00Z',
+            data_date='2024-01-01',
+            file_number='001',
+            file_extension='csv'
+        )
+        expected_file_name = 'fake-source_fake-dimension_2024-01-01_2024-01-01T00:00:00Z_001.csv'
+        self.assertEqual(file_name, expected_file_name)
+
+    @patch('to_data_library.data.gs.Client')
     @patch('to_data_library.data.bq.Client')
-    @patch('google.cloud.bigquery.LoadJobConfig')
-    @patch('to_data_library.data.bq.default')
-    def test_gs_to_bq(self, mock_default, mock_loadjobconfig,
-                      mock_bq_client, mock_tablereference, mock_datasetreference):
+    def test_gs_to_bq(self, mock_bq_client, mock_gs_client):
 
-        mock_default.return_value = 'first', 'second'
+        mock_prefix = 'fake-source/batch/2024-01-01/2024-01-01T00:00:00Z'
+        mock_file_name = 'fake-source_fake-dimension_2024-01-01_2024-01-01T00:00:00Z_001.csv'
+        mock_csv_content = b"name,number,date\nabc,1,'2024-01-01'\ndef,2,'2024-01-01'"
 
-        # Mock return values for LoadJobConfig
-        mock_loadjobconfig.return_value.source_format = 'CSV'
-        mock_loadjobconfig.return_value.skip_leading_rows = 1
-        mock_loadjobconfig.return_value.autodetect = True
-        mock_loadjobconfig.return_value.field_delimiter = ','
-        mock_loadjobconfig.return_value.write_disposition = 'WRITE_TRUNCATE'
-        mock_loadjobconfig.return_value.allow_quoted_newlines = True
-        mock_loadjobconfig.return_value.max_bad_records = 10
-        mock_loadjobconfig.return_value.schema_update_options = ['ALLOW_FIELD_ADDITION']
+        # Mock get_blobs on the gs.Client
+        mock_blob = Mock()
+        mock_blob.name = mock_prefix + '/' + mock_file_name
+        mock_blob.download_as_bytes.return_value = mock_csv_content
+        mock_gs_client.return_value.get_blobs = Mock(return_value=[mock_blob])
 
-        # Mock load_table_from_uris on the bq.Client
-        mock_bq_client.return_value.load_table_from_uris = Mock()
+        # Mock load_table_from_dataframe on the bq.Client
+        mock_bq_client.return_value.load_table_from_dataframe = Mock()
 
         client = transfer.Client('fake_project_name')
+
+        def transform_function(df):
+            df["date"] = pd.to_datetime(df["date"]).dt.date
+            return df
+
         client.gs_to_bq(
-            gs_uris="gs://{}/{}".format('fake_bucket_name', 'sample.csv'),
+            business_type='fake_business_type',
+            source_type='fake_source_type',
+            source='fake-source',
+            ingestion_type='batch',
+            etl_datetime_utc='2024-01-01T00:00:00Z',
+            dimension='fake-dimension',
             table='{}.{}.{}'.format('fake_project_name', 'fake_dataset_id', 'fake_table_id'),
+            file_number='001',
             write_preference='truncate',
             max_bad_records=10,
-            schema_update_options=['ALLOW_FIELD_ADDITION']
+            schema_update_options=['ALLOW_FIELD_ADDITION'],
+            partition_field='date',
+            data_date='2024-01-01',
+            transform_function=transform_function
         )
 
-        mock_datasetreference.assert_called_with(project='fake_project_name', dataset_id='fake_dataset_id')
-        mock_tablereference.assert_called_with(ANY, table_id='fake_table_id')
+        print(mock_bq_client.return_value.load_table_from_dataframe.call_args)
+        # Assert load_table_from_dataframe is called with the right parameters
 
-        # Assert that LoadJobConfig was created
-        mock_loadjobconfig.assert_called_once()
+        expected_df = transform_function(pd.DataFrame({
+                'name': ['abc', 'def'],
+                'number': [1, 2],
+                'date': ['2024-01-01', '2024-01-01'],
+                'etl_datetime_utc': ['2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z']
+            }))
 
-        # Check that the job_config attributes are correct
-        job_config = mock_loadjobconfig.return_value
-        self.assertEqual(job_config.source_format, 'CSV')
-        self.assertEqual(job_config.skip_leading_rows, 1)
-        self.assertEqual(job_config.autodetect, True)
-        self.assertEqual(job_config.field_delimiter, ',')
-        self.assertEqual(job_config.write_disposition, 'WRITE_TRUNCATE')
-        self.assertEqual(job_config.allow_quoted_newlines, True)
-        self.assertEqual(job_config.max_bad_records, 10)
-        self.assertEqual(job_config.schema_update_options, ['ALLOW_FIELD_ADDITION'])
+        # Check load_table_from_dataframe called once
+        mock_bq_client.return_value.load_table_from_dataframe.assert_called_once()
 
-        # Assert load_table_from_uris is called with the right parameters
-        mock_bq_client.return_value.load_table_from_uris.assert_called_once_with(
-            "gs://fake_bucket_name/sample.csv",
-            ANY,  # table_ref
-            job_config=job_config
+        actual_args, actual_kwargs = mock_bq_client.return_value.load_table_from_dataframe.call_args
+        actual_df = actual_args[0]  # Adjust index if DataFrame is not the first argument
+
+        # Check load_table_from_dataframe called with expected DataFrame
+        pd.testing.assert_frame_equal(actual_df, expected_df)
+
+        # Check the rest of the arguments used in load_table_from_dataframe:
+        assert actual_args[1:] == (
+            'fake_project_name.fake_dataset_id.fake_table_id',
+            'truncate',
+            True,
+            None,
+            '20240101',
+            'date',
+            {'max_bad_records': 10, 'schema_update_options': ['ALLOW_FIELD_ADDITION']}
         )
 
     @patch('boto3.client')
     @patch('boto3.resource')
-    @patch('to_data_library.data.bq.default')
     @patch('to_data_library.data.s3.Client')
     @patch("to_data_library.data.gs.storage.Client")
-    def test_s3_to_gs(self, mock_storage, mock_s3_client, mock_default, mock_s3_resource, mock_s3_boto):
+    def test_s3_to_gs(self, mock_storage, mock_s3_client, mock_s3_resource, mock_s3_boto):
         mock_aws_session = Mock()
         mock_aws_session.return_value = 'fake_session'
         mock_aws_session.client.return_value.get_paginator().paginate.return_value = []
 
-        mock_default.return_value = 'first', 'second'
-        client = transfer.Client(project=setup.project)
-        client.s3_to_gs(aws_session=mock_aws_session,
-                        s3_bucket_name='fake_s3_bucket',
-                        s3_object_name='download_sample.csv',
-                        gs_bucket_name='fake_gs_bucket_name',
-                        gs_file_name='transfer_s3_to_gs.csv')
+        client = transfer.Client(project='fake_project')
+
+        client.s3_to_gs(
+            aws_session=mock_aws_session,
+            s3_bucket_name='fake_s3_bucket',
+            s3_object_or_prefix_name='download_sample.csv',
+            business_type='fake_business_type',
+            source_type='fake_source_type',
+            source='fake-source',
+            dimension='fake-dimension',
+            repo_name='fake_repo_name',
+            ingestion_type='batch',
+            file_number='001',
+            wildcard=None,
+            data_date='2024-01-01',
+            etl_datetime_utc='2024-01-01T00:00:00Z'
+        )
 
         mock_s3_client.assert_called_once()
 
@@ -115,149 +169,86 @@ class TestTransfer(unittest.TestCase):
 
         self.assertEqual(res, [])
 
-    @patch("to_data_library.data.bq.Client")
-    @patch("to_data_library.data.gs.Client")
-    @patch("to_data_library.data.s3.Client")
-    def test_s3_to_bq_no_files(self, mock_s3, mock_gs, mock_bq):
-        mock_s3.return_value.list_files.return_value = []
+    def test_load_gcs_file_as_dataframe_csv(self):
+        mock_blob = Mock()
+        mock_blob.name = 'test.csv'
+        mock_blob.download_as_bytes.return_value = b'a,b\n1,2\n3,4'
+        client = transfer.Client(project='fake_project')
+        df = client.load_gcs_file_as_dataframe(mock_blob)
+        expected_df = pd.DataFrame({'a': [1, 3], 'b': [2, 4]})
+        pd.testing.assert_frame_equal(df, expected_df)
 
-        obj = transfer.Client(project="proj", impersonated_credentials="creds")
-        ok, uris = obj.s3_to_bq("aws_session", "bucket", "prefix", "p.d.t")
+    def test_load_gcs_file_as_dataframe_json(self):
+        mock_blob = Mock()
+        mock_blob.name = 'test.json'
+        mock_blob.download_as_bytes.return_value = b'{"a": 1, "b": 2}\n{"a": 3, "b": 4}'
+        client = transfer.Client(project='fake_project')
+        df = client.load_gcs_file_as_dataframe(mock_blob)
+        expected_df = pd.DataFrame({'a': [1, 3], 'b': [2, 4]})
+        pd.testing.assert_frame_equal(df, expected_df)
 
-        self.assertFalse(ok)
-        self.assertEqual(uris, [])
-
-    @patch("to_data_library.data.bq.Client")
-    @patch("to_data_library.data.gs.Client")
-    @patch("to_data_library.data.s3.Client")
-    def test_s3_to_bq_with_files_no_transform(self, mock_s3, mock_gs, mock_bq):
-        mock_s3.return_value.list_files.return_value = [{"name": "file1.csv"}]
-
-        obj = transfer.Client(project="proj", impersonated_credentials="creds")
-
-        ok, uris = obj.s3_to_bq(
-            "aws_session", "bucket", "prefix", "p.d.t", gs_bucket_name="gcs"
-        )
-
-        self.assertTrue(ok)
-        self.assertEqual(uris, ["gs://gcs/file1.csv"])
-        mock_s3.return_value.download.assert_called_once()
-        mock_gs.return_value.upload.assert_called_once()
-        mock_bq.return_value.load_table_from_uris.assert_called_once()
-
-    @patch("to_data_library.data.bq.Client")
-    @patch("to_data_library.data.gs.Client")
-    @patch("to_data_library.data.s3.Client")
-    def test_s3_to_bq_with_transform(self, mock_s3, mock_gs, mock_bq):
-        mock_s3.return_value.list_files.return_value = [{"name": "file1.csv"}]
-
-        obj = transfer.Client(project="proj", impersonated_credentials="creds")
-
-        # Prepare a dummy CSV file for transform_fn to modify
-        with tempfile.TemporaryDirectory() as tmpdir:
-            file_path = os.path.join(tmpdir, "file1.csv")
-            pd.DataFrame({"a": [1]}).to_csv(file_path, index=False)
-
-            # fake download: copy our prepared CSV
-            mock_s3.return_value.download.side_effect = \
-                lambda b, n, local_path: os.replace(file_path, local_path)
-
-            def transform(df):
-                df["a"] += 1
-                return df
-
-            ok, uris = obj.s3_to_bq(
-                "aws_session", "bucket", "prefix", "p.d.t",
-                gs_bucket_name="gcs", transform_fn=transform
-            )
-
-        self.assertTrue(ok)
-        self.assertEqual(uris, ["gs://gcs/file1.csv"])
-
-    @patch("to_data_library.data.bq.Client")
-    @patch("to_data_library.data.gs.Client")
-    @patch("to_data_library.data.s3.Client")
-    def test_s3_to_bq_partitioning_without_date_raises(self, mock_s3, mock_gs, mock_bq):
-        mock_s3.return_value.list_files.return_value = [{"name": "file1.csv"}]
-
-        obj = transfer.Client(project="proj", impersonated_credentials="creds")
-
-        with self.assertRaises(ValueError) as ctx:
-            obj.s3_to_bq(
-                "aws_session", "bucket", "prefix", "p.d.t",
-                gs_bucket_name="gcs", partition_field="created_at"
-            )
-
-        self.assertIn("partition_field supplied without partition_date", str(ctx.exception))
-
-    @patch("to_data_library.data.bq.Client")
-    @patch("to_data_library.data.gs.Client")
-    @patch("to_data_library.data.s3.Client")
-    def test_s3_to_bq_bq_load_failure(self, mock_s3, mock_gs, mock_bq):
-        mock_s3.return_value.list_files.return_value = [{"name": "file1.csv"}]
-        mock_bq.return_value.load_table_from_uris.side_effect = Exception("bq fail")
-
-        obj = transfer.Client(project="proj", impersonated_credentials="creds")
-
-        ok, uris = obj.s3_to_bq(
-            "aws_session", "bucket", "prefix", "p.d.t", gs_bucket_name="gcs"
-        )
-
-        self.assertFalse(ok)
+    def test_load_gcs_file_as_dataframe_unsupported(self):
+        mock_blob = Mock()
+        mock_blob.name = 'test.txt'
+        mock_blob.download_as_bytes.return_value = b''
+        client = transfer.Client(project='fake_project')
+        with self.assertRaises(ValueError) as exc:
+            client.load_gcs_file_as_dataframe(mock_blob)
+        self.assertIn('Unsupported file type', str(exc.exception))
 
 
 class TestTransferEdgeCases(unittest.TestCase):
     def setUp(self):
         self.client = transfer.Client('fake_project')
 
-    def test_gs_to_bq_invalid_source_format(self):
-        with patch('google.cloud.bigquery.Client'), \
-             patch('google.cloud.bigquery.DatasetReference'), \
-             patch('google.cloud.bigquery.TableReference'), \
-             patch('google.cloud.bigquery.LoadJobConfig'), \
-             patch.object(transfer.logs.client.logger, 'error') as mock_error:
-            with self.assertRaises(SystemExit):
-                self.client.gs_to_bq(
-                    gs_uris='gs://bucket/file.unknown',
-                    table='p.d.t',
-                    write_preference='truncate',
-                    source_format='NOT_A_FORMAT'
-                )
-            mock_error.assert_called_with('Invalid SourceFormat entered: NOT_A_FORMAT')
+    @patch('to_data_library.data.gs.Client')
+    @patch('to_data_library.data.bq.Client')
+    @patch.object(transfer.logs.client.logger, 'error')
+    def test_gs_to_bq_invalid_source_format(self, mock_error, mock_bq_client, mock_gs_client):
+        mock_prefix = 'fake-source/batch/2024-01-01T00:00:00Z'
+        mock_file_name = 'fake-source_fake-dimension_2024-01-01T00:00:00Z_001.not_a_file_type'
 
-    def test_gs_to_bq_partition_field_without_date(self):
-        with patch('google.cloud.bigquery.Client'), \
-             patch('google.cloud.bigquery.DatasetReference'), \
-             patch('google.cloud.bigquery.TableReference'), \
-             patch('google.cloud.bigquery.LoadJobConfig'), \
-             patch.object(transfer.logs.client.logger, 'error') as mock_error:
-            with self.assertRaises(SystemExit):
-                self.client.gs_to_bq(
-                    gs_uris='gs://bucket/file.csv',
-                    table='p.d.t',
-                    write_preference='truncate',
-                    partition_field='field1'
-                )
-            mock_error.assert_called()
+        # Mock get_blobs on the gs.Client
+        mock_blob = Mock()
+        mock_blob.name = mock_prefix + '/' + mock_file_name
+        mock_blob.download_as_bytes.return_value = b"some content"
+        mock_gs_client.return_value.get_blobs = Mock(return_value=[mock_blob])
 
-    def test_s3_to_gs_cleanup_and_logging(self):
-        with patch('to_data_library.data.s3.Client') as mock_s3, \
-             patch('to_data_library.data.gs.Client') as mock_gs, \
-             patch('os.remove') as mock_remove, \
-             patch('os.path.exists', return_value=True), \
-             patch.object(transfer.logs.client.logger, 'info') as mock_info:
-            mock_s3.return_value.download.return_value = '/tmp/file.csv'
-            mock_gs.return_value.upload.return_value = None
-            # Simulate one file found
-            with patch.object(self.client, '_get_keys_in_s3_bucket', return_value=['file.csv']):
-                self.client.s3_to_gs(
-                    aws_session=Mock(),
-                    s3_bucket_name='bucket',
-                    s3_object_name='file.csv',
-                    gs_bucket_name='gs-bucket',
-                )
-                mock_remove.assert_called_once_with('/tmp/file.csv')
-                mock_info.assert_any_call('Deleted local file /tmp/file.csv')
+        success, message = self.client.gs_to_bq(
+                business_type='fake_business_type',
+                source_type='fake_source_type',
+                source='fake-source',
+                ingestion_type='batch',
+                etl_datetime_utc='2024-01-01T00:00:00Z',
+                dimension='fake-dimension',
+                table='{}.{}.{}'.format('fake_project_name', 'fake_dataset_id', 'fake_table_id')
+        )
+        assert not success
+        assert message == 'Unsupported file type: not_a_file_type'
+
+    @patch('to_data_library.data.s3.Client')
+    @patch('to_data_library.data.gs.Client')
+    @patch('os.remove')
+    @patch('os.path.exists', return_value=True)
+    @patch.object(transfer.logs.client.logger, 'info')
+    def test_s3_to_gs_cleanup_and_logging(self, mock_info, mock_path_exists, mock_remove, mock_gs, mock_s3):
+        mock_s3.return_value.download.return_value = '/tmp/file.csv'
+        mock_gs.return_value.upload.return_value = None
+        # Simulate one file found
+        with patch.object(self.client, '_get_keys_in_s3_bucket', return_value=['file.csv']):
+
+            self.client.s3_to_gs(
+                aws_session=Mock(),
+                s3_bucket_name='fake_s3_bucket',
+                s3_object_or_prefix_name='file.csv',
+                business_type='fake_business_type',
+                source_type='fake_source_type',
+                source='fake-source',
+                dimension='fake-dimension'
+            )
+
+            mock_remove.assert_called_once_with('/tmp/file.csv')
+            mock_info.assert_any_call('Deleted local file /tmp/file.csv')
 
     def test_get_keys_in_s3_bucket_empty_and_missing_contents(self):
         # Empty pages

--- a/to_data_library/data/bq.py
+++ b/to_data_library/data/bq.py
@@ -269,7 +269,6 @@ class Client:
 
         logs.client.logger.info(f'Loading BigQuery table {table_id} from DataFrame')
         job = self.bigquery_client.load_table_from_dataframe(data_df, table_ref, job_config=job_config)
-
         job.result()
 
     def run_query(self, query=None, query_file_name=None, params=(), destination=None, write_preference='empty',

--- a/to_data_library/data/gs.py
+++ b/to_data_library/data/gs.py
@@ -37,7 +37,7 @@ class Client:
         with open(destination_file_name, 'wb') as file_obj:
             self.storage_client.download_blob_to_file(gs_uri, file_obj)
 
-    def upload(self, source_file_name, bucket_name, blob_name=None):
+    def upload(self, source_file_name, bucket_name, blob_name=None, metadata=None):
         """Upload from local to Google Storage.
 
         Args:
@@ -49,6 +49,7 @@ class Client:
             blob_name = source_file_name.split('/')[-1]
 
         blob = self.storage_client.bucket(bucket_name).blob(blob_name)
+        blob.metadata = metadata
         blob.upload_from_filename(source_file_name)
 
     def list_bucket_uris(self, bucket_name, file_type='csv', prefix=None):

--- a/to_data_library/data/gs.py
+++ b/to_data_library/data/gs.py
@@ -52,6 +52,19 @@ class Client:
         blob.metadata = metadata
         blob.upload_from_filename(source_file_name)
 
+    def get_blobs(self, bucket_name, prefix=None):
+        """Get the blobs in a bucket
+
+        Args:
+            bucket_name (str): the bucket name (no 'gs://' prefix)
+            prefix (str): the folder path to the files
+
+        Returns:
+            list: The list of the contents
+        """
+        blobs = self.storage_client.list_blobs(bucket_name, prefix=prefix)
+        return blobs
+
     def list_bucket_uris(self, bucket_name, file_type='csv', prefix=None):
         """Lists the files in a bucket
 
@@ -63,7 +76,7 @@ class Client:
         Returns:
             list: The list of the contents
         """
-        blobs = self.storage_client.list_blobs(bucket_name, prefix=prefix)
+        blobs = self.get_blobs(bucket_name, prefix=prefix)
         gs_uris = [f"gs://{bucket_name}/{blob.name}" for blob in blobs if blob.name.endswith(file_type)]
         return gs_uris
 

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -437,7 +437,6 @@ class Client:
             ingestion_type='batch',
             file_number='000',
             wildcard=None,
-            additional_metadata=None,
             partition_date=None,
             etl_datetime_utc=None
             ) -> Tuple[bool, str]:
@@ -485,8 +484,6 @@ class Client:
         gs_prefix = self.build_gs_prefix(source, ingestion_type, etl_datetime_utc, partition_date)
 
         metadata = self.build_gs_metadata(s3_bucket_name, s3_object_or_prefix_name, etl_datetime_utc, repo_name)
-        if additional_metadata:
-            metadata.update(additional_metadata)
 
         # Retrieve the file(s) from S3 matching to the object
         logs.client.logger.info('Finding files in S3 bucket')

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -2,6 +2,7 @@ import datetime
 import os
 import re
 from io import BytesIO
+from pathlib import Path
 from typing import Tuple
 
 import pandas as pd
@@ -122,14 +123,16 @@ class Client:
         Returns:
             (bool, str): Tuple with success status and message
         """
+
         bucket_name = self.build_gs_bucket_name(business_type, source_type)
         prefix = self.build_gs_prefix(source, ingestion_type, etl_datetime_utc, partition_date)
         file_name = self.build_gs_file_name(source, dimension, etl_datetime_utc, partition_date, file_number)
 
         gs_client = gs.Client(self.project, impersonated_credentials=self.impersonated_credentials)
 
-        bucket = gs_client.bucket(bucket_name)
+        bucket = gs_client.get_bucket(bucket_name)
         blobs = bucket.list_blobs(prefix=prefix)
+
         # Get all blobs in the bucket
         for blob in blobs:
             # Get all blobs with this prefix and filename
@@ -356,7 +359,7 @@ class Client:
             >>> client = transfer.Client(project='my-project-id')
             >>> bucket_name = client.build_gs_bucket_name('markets', 'pos')
         """
-        return '-'.join([business_type, source_type])
+        return '-'.join([self.project, business_type, source_type])
 
     def build_gs_prefix(self, source, ingestion_type, etl_datetime_utc, partition_date=None) -> str:
         """
@@ -379,7 +382,15 @@ class Client:
         parts.append(etl_datetime_utc)
         return '/'.join(parts)
 
-    def build_gs_file_name(self, source, dimension, etl_datetime_utc, partition_date=None, file_number=None) -> str:
+    def build_gs_file_name(
+            self,
+            source,
+            dimension,
+            etl_datetime_utc,
+            partition_date=None,
+            file_number=None,
+            file_extension=None
+    ) -> str:
         """
         Builds the gs file name based on source, dimension, partition date, etl datetime and file number
         Args:
@@ -387,6 +398,8 @@ class Client:
             dimension (str): The dimension of the data being ingested. E.g. 'audience', 'sales'
             etl_datetime_utc (str): load datetime string to use in the path
             partition_date (str): The partition date, e.g. '2021-01-01'
+            file_number (str): The file number
+            file_extension (str): The file extension without the leading dot, e.g. 'csv', 'parquet
         Returns:
             str: The gs file name
         Example:
@@ -400,7 +413,10 @@ class Client:
         parts.append(etl_datetime_utc)
         if file_number:
             parts.append(file_number)
-        return '_'.join(parts)
+        file_name = '_'.join(parts)
+        if file_extension:
+            file_name = '.'.join([file_name, file_extension])
+        return file_name
 
     def build_gs_metadata(self, s3_bucket_name, s3_object_name, etl_datetime_utc, repo_name) -> dict:
         """
@@ -450,7 +466,7 @@ class Client:
         Args:
             aws_session: authenticated AWS session.
             s3_bucket_name (str): s3 bucket name
-            s3_object_or_prefix_name (str): s3 object name or prefix to match multiple files to copy
+            s3_object_or_prefix_name (str): s3 object name or prefix to match multiple files to copy,
             business_type (str): The business type of the data being ingested. Generally 'markets' or 'web'.
             source_type (str): The source type of the data being ingested. E.g. 'pos', 'user', 'db', 'tracking', 'ads'
             source (str): The source of the data being ingested. E.g. 'mariadb_datacafe', 'tenzo', 'facebook'
@@ -471,11 +487,19 @@ class Client:
             >>> success, message = client.s3_to_gs(aws_session,
             >>>                                 s3_bucket_name='my-s3-bucket',
             >>>                                 s3_object_or_prefix_name='my-s3-object-or-prefix',
+            >>>                                 project='tog-dev-dt-lnd',
             >>>                                 business_type='markets',
             >>>                                 source_type='pos',
             >>>                                 source='tenzo',
             >>>                                 dimension='sales')
         """
+
+        # Quality Checks
+        # Ensure no underscores in source or dimension
+        for element in [source, dimension]:
+            if '_' in element:
+                return False,  f"Error: {element} must not contain underscores."
+
         if not etl_datetime_utc:
             etl_datetime_utc = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
 
@@ -497,7 +521,7 @@ class Client:
             prefix_name=s3_object_or_prefix_name,
             wildcard=wildcard)
 
-        logs.client.logger.info(f'Found {str(s3_files)} files in S3')
+        logs.client.logger.info(f'Found {len(s3_files)} files in S3')
 
         # Get S3 and GS clients
         s3_client = s3.Client(aws_session)
@@ -509,8 +533,6 @@ class Client:
 
             # Try to download the file to local
             try:
-                gs_file_name = self.build_gs_file_name(source, dimension, etl_datetime_utc, partition_date, file_number)
-                gs_file_path = '/'.join([gs_prefix, gs_file_name])
                 local_file = s3_client.download(s3_bucket_name, s3_file)
                 logs.client.logger.info(f'Successfully downloaded {local_file} to local')
             except Exception as e:
@@ -519,10 +541,23 @@ class Client:
 
             # Try to upload file from local to GCS.
             try:
-                bucket = gs_client.bucket(gs_bucket_name)
-                blob = bucket.blob(gs_file_path)
-                blob.metadata = metadata
-                blob.upload_from_filename(local_file)
+                s3_file_extension = '.'.join(Path(s3_file).suffixes).lstrip('.')
+                gs_file_name = self.build_gs_file_name(
+                    source,
+                    dimension,
+                    etl_datetime_utc,
+                    partition_date,
+                    file_number,
+                    s3_file_extension
+                )
+                gs_file_path = '/'.join([gs_prefix, gs_file_name])
+
+                gs_client.upload(
+                    source_file_name=local_file,
+                    bucket_name=gs_bucket_name,
+                    blob_name=gs_file_path,
+                    metadata=metadata
+                )
                 logs.client.logger.info(
                     f'Successfully uploaded {local_file} to {gs_bucket_name}/{gs_file_path}')
             except Exception as e:
@@ -557,7 +592,6 @@ class Client:
 
         pages = paginator.paginate(Bucket=bucket_name, Prefix=prefix_name)
         for page in pages:
-            print(f"page: {page}")
             for obj in page.get('Contents', []):
                 key = obj['Key']
                 if not key.endswith('/') and re.match(regex, key):

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import re
 import sys
@@ -369,30 +370,138 @@ class Client:
         s3_client.upload(local_file,
                          s3_bucket)
 
-    def s3_to_gs(self, aws_session, s3_bucket_name,
-                 s3_object_or_prefix_name, gs_bucket_name, gs_file_name=None, wildcard=None, metadata=None):
+    def build_gs_bucket_name(self, business_type, source_type) -> str:
         """
-        Exports file(s) from S3 bucket to Google storage bucket
-        Added threading to speed up execution
+        Builds the gs bucket name based on business type and source type
+        Args:
+            business_type (str): The business type of the data being ingested. Generally 'markets' or 'web'.
+            source_type (str): The source type of the data being ingested. E.g. 'pos', 'user', 'db', 'tracking', 'ads'
+        Returns:
+            str: The gs bucket name
+        Example:
+            >>> from to_data_library.data import transfer
+            >>> client = transfer.Client(project='my-project-id')
+            >>> bucket_name = client.build_gs_bucket_name('markets', 'pos')
+        """
+        return '-'.join([business_type, source_type])
+
+    def build_gs_prefix(self, source, ingestion_type, etl_datetime, partition_name='data') -> str:
+        """
+        Builds the gs prefix based on source, ingestion type, etl datetime and partition name
+        Args:
+            source (str): The source of the data being ingested. E.g. 'mariadb_datacafe', 'tenzo', 'facebook'
+            ingestion_type (str): The type of ingestion. Either 'batch' or 'stream'.
+            etl_datetime (str): load datetime string to use in the path
+            partition_name (str): name of the partition, default 'data'
+        Returns:
+            str: The gs prefix
+        Example:
+            >>> from to_data_library.data import transfer
+            >>> client = transfer.Client(project='my-project-id')
+            >>> prefix = client.build_gs_prefix('tenzo', 'batch', '20250102_120000', '2021-01-01')
+        """
+        return '/'.join([source, ingestion_type, partition_name, etl_datetime])
+
+    def build_gs_file_name(self, source, dimension, partition_date, etl_datetime, file_number) -> str:
+        """
+        Builds the gs file name based on source, dimension, partition date, etl datetime and file number
+        Args:
+            source (str): The source of the data being ingested. E.g. 'mariadb_datacafe', 'tenzo', 'facebook'
+            dimension (str): The dimension of the data being ingested. E.g. 'audience', 'sales'
+            partition_date (str): The partition date, e.g. '2021-01-01'
+            etl_datetime (str): load datetime string to use in the path
+            file_number (str): The file number, e.g. '000'
+        Returns:
+            str: The gs file name
+        Example:
+            >>> from to_data_library.data import transfer
+            >>> client = transfer.Client(project='my-project-id')
+            >>> file_name = client.build_gs_file_name('tenzo', 'sales', '2021-01-01', '20250102_120000', '000')
+        """
+        return '_'.join([source, dimension, partition_date, etl_datetime, file_number])
+
+    def build_gs_metadata(self, s3_bucket_name, s3_object_name, etl_datetime) -> dict:
+        """
+        Builds the gs metadata based on s3 bucket name, s3 object name and etl datetime
+        Args:
+            s3_bucket_name (str): s3 bucket name
+            s3_object_name (str): s3 object name
+            etl_datetime (str): load datetime string to use in the path
+        Returns:
+            dict: The gs metadata
+        Example:
+            >>> from to_data_library.data import transfer
+            >>> client = transfer.Client(project='my-project-id')
+            >>> metadata = client.build_gs_metadata('my-s3-bucket', 'my-s3-object', '20250102_120000')
+        """
+        return {
+            's3_bucket_name': s3_bucket_name,
+            's3_object_name': s3_object_name,
+            'etl_datetime': etl_datetime
+        }
+
+    def s3_to_gs(
+            self,
+            aws_session,
+            s3_bucket_name,
+            s3_object_or_prefix_name,
+            business_type,
+            source_type,
+            source,
+            dimension,
+            ingestion_type='batch',
+            file_number='000',
+            wildcard=None,
+            additional_metadata=None,
+            partition_name='data',
+            etl_datetime=None
+            ) -> (bool, str):
+        """
+        - Exports file(s) from S3 bucket to Google storage bucket
+        - Enforces the use of the standard naming conventions for bucket, prefix, file name and metadata
+          as per documentation here:
+          https://timeoutgroup.atlassian.net/wiki/spaces/TD/pages/3824189448/ELT+Process
+        - Added threading to speed up execution
 
         Args:
-          aws_session: authenticated AWS session.
-          s3_bucket_name (str): s3 bucket name
-          s3_object_or_prefix_name (str): s3 object name or prefix to match multiple files to copy
-          gs_bucket_name (str): Google storage bucket name (no 'gs://' prefix)
-          gs_file_name (str): GS file name
-          wildcard (str): regex wildcard (default '.*')
-          metadata (dict): custom metadata to set on the GS object
+            aws_session: authenticated AWS session.
+            s3_bucket_name (str): s3 bucket name
+            s3_object_or_prefix_name (str): s3 object name or prefix to match multiple files to copy
+            business_type (str): The business type of the data being ingested. Generally 'markets' or 'web'.
+            source_type (str): The source type of the data being ingested. E.g. 'pos', 'user', 'db', 'tracking', 'ads'
+            source (str): The source of the data being ingested. E.g. 'mariadb_datacafe', 'tenzo', 'facebook'
+            dimension (str): The dimension of the data being ingested. E.g. 'audience', 'sales'
+            ingestion_type (str, Optional): The type of ingestion. Either 'batch' or 'stream'. Defaults to 'batch'.
+            file_number (str, Optional): The file number. Defaults to '000'.
+            wildcard (str): regex wildcard (default '.*')
+            additional_metadata (dict): custom metadata to set on the GS object
+            partition_name (str): name of the partition, default 'data'
+            etl_datetime (str): load datetime string to use in the path and file name
+        Returns:
+            (bool, str): Tuple with success status and message
 
         Example:
             >>> from to_data_library.data import transfer
             >>> client = transfer.Client(project='my-project-id')
-            >>> client.s3_to_gs(aws_session,
-            >>>                 s3_bucket_name='my-s3-bucket_name',
-            >>>                 s3_object_or_prefix_name='my-s3-file-prefix',
-            >>>                 gs_bucket_name='my-gs-bucket-name',
-            >>>                 gs_file_name='gs_file_name')
+            >>> success, message = client.s3_to_gs(aws_session,
+            >>>                                 s3_bucket_name='my-s3-bucket',
+            >>>                                 s3_object_or_prefix_name='my-s3-object-or-prefix',
+            >>>                                 business_type='markets',
+            >>>                                 source_type='pos',
+            >>>                                 source='tenzo',
+            >>>                                 dimension='sales')
         """
+        if not etl_datetime:
+            etl_datetime = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
+
+        # Build the GS bucket name, prefix, file name and metadata
+        gs_bucket_name = self.build_gs_bucket_name(business_type, source_type)
+        gs_prefix = self.build_gs_prefix(source, ingestion_type, etl_datetime, partition_name)
+        gs_file_name = self.build_gs_file_name(source, dimension, partition_name, etl_datetime)
+
+        metadata = self.build_gs_metadata(s3_bucket_name, s3_object_or_prefix_name, etl_datetime)
+        if additional_metadata:
+            metadata.update(additional_metadata)
 
         # Retrieve the file(s) from S3 matching to the object
         logs.client.logger.info('Finding files in S3 bucket')
@@ -408,36 +517,42 @@ class Client:
 
         logs.client.logger.info(f'Found {str(s3_files)} files in S3')
 
-        # For every key found in s3, download to local and then upload to desired GS bucket.
+        # Get S3 and GS clients
         s3_client = s3.Client(aws_session)
         gs_client = gs.Client(self.project, impersonated_credentials=self.impersonated_credentials)
 
-        for s3_file in s3_files:
-            # Try to download the file to 'local'
+        # For every key found in s3, download to local and then upload to desired GS bucket.
+        for file_number, s3_file in enumerate(s3_files, start=0):
+            file_number = f"{file_number:03d}"  # zero-padded to 3 digits
+
+            # Try to download the file to local
             try:
+                gs_file_name = self.build_gs_file_name(source, dimension, partition_name, etl_datetime, file_number)
+                gs_file_path = '/'.join([gs_prefix, gs_file_name])
                 local_file = s3_client.download(s3_bucket_name, s3_file)
                 logs.client.logger.info(f'Successfully downloaded {local_file} to local')
             except Exception as e:
                 logs.client.logger.error(f"Failed to download {local_file} to local: {e}")
-
-            gs_file_name = (gs_file_name if gs_file_name is not None else s3_file) \
-                if len(s3_files) == 1 else s3_file
+                return False, str(e)
 
             # Try to upload file from local to GCS.
             try:
                 bucket = gs_client.bucket(gs_bucket_name)
-                blob = bucket.blob(gs_file_name)
+                blob = bucket.blob(gs_file_path)
                 blob.metadata = metadata
                 blob.upload_from_filename(local_file)
                 logs.client.logger.info(
-                    f'Successfully uploaded {local_file} to {gs_bucket_name}/{gs_file_name}')
+                    f'Successfully uploaded {local_file} to {gs_bucket_name}/{gs_file_path}')
             except Exception as e:
                 logs.client.logger.error(
                     f"Failed to upload {local_file} to {gs_bucket_name}/{gs_file_name}: {e}")
+                return False, str(e)
             finally:
                 if os.path.exists(local_file):
                     os.remove(local_file)
                     logs.client.logger.info(f'Deleted local file {local_file}')
+
+        return True, f'Successfully transferred {len(s3_files)} files from S3 to GS'
 
     def _get_keys_in_s3_bucket(self, aws_session, bucket_name, prefix_name, wildcard='.*'):
         """Generate a list of keys for objects in an s3 bucket.
@@ -467,151 +582,3 @@ class Client:
                     s3_files.append(obj.get('Key'))
 
         return s3_files
-
-    def s3_to_bq(
-        self,
-        aws_session,
-        bucket_name,
-        object_or_prefix_name,
-        bq_table,
-        write_preference,
-        auto_detect=True,
-        separator=',',
-        skip_leading_rows=True,
-        schema=None,
-        partition_date=None,
-        partition_field=None,
-        source_format='CSV',
-        max_bad_records=0,
-        gs_bucket_name=None,
-        gs_file_name=None
-    ):
-
-        """
-        Exports S3 file to BigQuery table via GCS staging.
-
-        Args:
-        aws_session: authenticated AWS session.
-        bucket_name (str): s3 bucket name
-        object_or_prefix_name (str): s3 object name or prefix to copy
-        bq_table (str): The BigQuery table. For example: ``my-project-id.my-dataset.my-table``
-        write_preference (str): The option to specify what action to take when you load data from a source file.
-            Value can be one of
-                ``'empty'``: Writes the data only if the table is empty.
-                ``'append'``: Appends the data to the end of the table.
-                ``'truncate'``: Erases all existing data in a table before writing the new data.
-        auto_detect (boolean, Optional):  True if the schema should automatically be detected otherwise False.
-            Defaults to `True`.
-        separator (str, optional): The separator. Defaults to `,`.
-        skip_leading_rows (boolean, Optional):  True to skip the first row of the file otherwise False. Defaults to
-            `True`.
-        schema (tuple, optional): The BigQuery table schema. For example: ``(('first_field','STRING'),
-        ('second_field', 'STRING'))``
-        partition_date (str, Optional): The ingestion date for partitioned BigQuery table. For example: ``20210101``.
-        partition_field (str, Optional): The field on which the destination table is partitioned.
-        The field must be a top-level TIMESTAMP or DATE field. Must be used in conjunction with partition_date.
-        source_format (str, Optional): The file format (CSV, JSON, PARQUET or AVRO). Defaults to 'CSV'.
-        max_bad_records (int, Optional): The maximum number of rows with errors. Defaults to 0.
-        gs_bucket_name (str, required): The GCS bucket to stage the file.
-        gs_file_name (str, optional): The name for the staged file in GCS.
-
-        Example:
-            >>> from to_data_library.data import transfer
-            >>> client = transfer.Client(project='my-project-id')
-            >>> client.s3_to_bq(aws_connection,
-            >>>                 bucket_name='my-s3-bucket_name',
-            >>>                 object_or_prefix_name='my-s3-object-name',
-            >>>                 bq_table='my-project-id.my-dataset.my-table',
-            >>>                 gs_bucket_name='my-gcs-bucket')
-        """
-
-        # Download S3 file to local
-        s3_client = s3.Client(aws_session)
-        local_file = os.path.join('/tmp/', object_or_prefix_name)
-        s3_client.download(bucket_name, object_or_prefix_name, local_file)
-
-        # Upload local file to GCS
-        if not gs_bucket_name:
-            logs.client.logger.error("gs_bucket_name must be provided to stage file in GCS before loading to BQ")
-            raise ValueError("gs_bucket_name must be provided")
-        gs_client = gs.Client(self.project, impersonated_credentials=self.impersonated_credentials)
-        gs_file_name = gs_file_name if gs_file_name else object_or_prefix_name
-        gs_client.upload(local_file, gs_bucket_name, gs_file_name)
-        gs_uri = f"gs://{gs_bucket_name}/{gs_file_name}"
-
-        project, dataset_id, table_id = bq_table.split('.')
-        dataset_ref = bigquery.DatasetReference(project=project, dataset_id=dataset_id)
-
-        job_config = bigquery.LoadJobConfig(
-            autodetect=auto_detect,
-            write_disposition=get_bq_write_disposition(write_preference),
-            allow_quoted_newlines=True,
-            max_bad_records=max_bad_records
-        )
-
-        if skip_leading_rows:
-            job_config.skip_leading_rows = 1
-
-        # Partitioning logic (same as gs_to_bq)
-        if partition_date and not partition_field:
-            job_config.time_partitioning = bigquery.TimePartitioning(
-                    type_=bigquery.TimePartitioningType.DAY
-                )
-            table_id += f'${partition_date}'
-        elif partition_date and partition_field:
-            job_config.time_partitioning = bigquery.TimePartitioning(
-                    type_=bigquery.TimePartitioningType.DAY,
-                    field=partition_field
-                )
-            table_id += f'${partition_date}'
-        elif partition_field and not partition_date and write_preference == 'truncate':
-            logs.client.logger.error(
-                    "Error: if partition_field is supplied, partition_date must also be supplied"
-                )
-            raise ValueError("partition_field supplied without partition_date")
-
-        table_ref = bigquery.TableReference(dataset_ref, table_id=table_id)
-
-        if separator:
-            job_config.field_delimiter = separator
-
-        # Source format
-        if source_format == 'CSV':
-            job_config.source_format = bigquery.SourceFormat.CSV
-        elif source_format == 'JSON':
-            job_config.source_format = bigquery.SourceFormat.NEWLINE_DELIMITED_JSON
-        elif source_format == 'AVRO':
-            job_config.source_format = bigquery.SourceFormat.AVRO
-        elif source_format == 'PARQUET':
-            job_config.source_format = bigquery.SourceFormat.PARQUET
-        else:
-            logs.client.logger.error(
-                f"Invalid SourceFormat entered: {source_format}")
-            raise ValueError(f"Invalid SourceFormat entered: {source_format}")
-
-        # Schema as tuple/list of tuples
-        if schema:
-            if isinstance(schema[0], bigquery.SchemaField):
-                job_config.schema = schema
-            else:
-                job_config.schema = [bigquery.SchemaField(field[0], field[1]) for field in schema]
-
-        bq_client = bq.Client(project, impersonated_credentials=self.impersonated_credentials)
-        try:
-            bq_client.create_dataset(dataset_id)
-        except exceptions.Conflict:
-            logs.client.logger.info(f'Dataset {dataset_id} Already exists')
-
-        logs.client.logger.info(f'Loading BigQuery table {bq_table} from {gs_uri}')
-        try:
-            bq_client.load_table_from_uris(
-                [gs_uri], table_ref, job_config=job_config
-            )
-        except Exception as e:
-            logs.client.logger.error(f"Unexpected error occurred: {e}")
-            return False, str(e)
-        finally:
-            if os.path.exists(local_file):
-                os.remove(local_file)
-                logs.client.logger.info(f'Deleted local file {local_file}')
-        logs.client.logger.info('Loading completed')

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -184,8 +184,12 @@ class Client:
 
                 # Split df into separate dataframes for each partition date
                 partition_dates = df[partition_field].unique()
-                logs.client.logger.info(f"Found {len(partition_dates)} partition dates.")
-                logs.client.logger.info("Splitting dataframe into separate partitions for loading.")
+                multiple_partitions = len(partition_dates) > 1
+                logs.client.logger.info(
+                    f"Found {len(partition_dates)} partition{'s' if multiple_partitions else ''} in the data."
+                    )
+                if multiple_partitions:
+                    logs.client.logger.info("Splitting dataframe into separate partitions for loading.")
                 for date in partition_dates:
                     partition_df = df[df[partition_field] == date]
                     try:

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -370,7 +370,7 @@ class Client:
                          s3_bucket)
 
     def s3_to_gs(self, aws_session, s3_bucket_name,
-                 s3_object_name, gs_bucket_name, gs_file_name=None, wildcard=None):
+                 s3_object_or_prefix_name, gs_bucket_name, gs_file_name=None, wildcard=None, metadata=None):
         """
         Exports file(s) from S3 bucket to Google storage bucket
         Added threading to speed up execution
@@ -378,17 +378,18 @@ class Client:
         Args:
           aws_session: authenticated AWS session.
           s3_bucket_name (str): s3 bucket name
-          s3_object_name (str): s3 object name or prefix to match multiple files to copy
+          s3_object_or_prefix_name (str): s3 object name or prefix to match multiple files to copy
           gs_bucket_name (str): Google storage bucket name (no 'gs://' prefix)
           gs_file_name (str): GS file name
           wildcard (str): regex wildcard (default '.*')
+          metadata (dict): custom metadata to set on the GS object
 
         Example:
             >>> from to_data_library.data import transfer
             >>> client = transfer.Client(project='my-project-id')
             >>> client.s3_to_gs(aws_session,
             >>>                 s3_bucket_name='my-s3-bucket_name',
-            >>>                 s3_object_name='my-s3-file-prefix',
+            >>>                 s3_object_or_prefix_name='my-s3-file-prefix',
             >>>                 gs_bucket_name='my-gs-bucket-name',
             >>>                 gs_file_name='gs_file_name')
         """
@@ -402,7 +403,7 @@ class Client:
         s3_files = self._get_keys_in_s3_bucket(
             aws_session=aws_session,
             bucket_name=s3_bucket_name,
-            prefix_name=s3_object_name,
+            prefix_name=s3_object_or_prefix_name,
             wildcard=wildcard)
 
         logs.client.logger.info(f'Found {str(s3_files)} files in S3')
@@ -424,7 +425,10 @@ class Client:
 
             # Try to upload file from local to GCS.
             try:
-                gs_client.upload(local_file, gs_bucket_name, gs_file_name)
+                bucket = gs_client.bucket(gs_bucket_name)
+                blob = bucket.blob(gs_file_name)
+                blob.metadata = metadata
+                blob.upload_from_filename(local_file)
                 logs.client.logger.info(
                     f'Successfully uploaded {local_file} to {gs_bucket_name}/{gs_file_name}')
             except Exception as e:
@@ -468,7 +472,7 @@ class Client:
         self,
         aws_session,
         bucket_name,
-        object_name,
+        object_or_prefix_name,
         bq_table,
         write_preference,
         auto_detect=True,
@@ -489,7 +493,7 @@ class Client:
         Args:
         aws_session: authenticated AWS session.
         bucket_name (str): s3 bucket name
-        object_name (str): s3 object name to copy
+        object_or_prefix_name (str): s3 object name or prefix to copy
         bq_table (str): The BigQuery table. For example: ``my-project-id.my-dataset.my-table``
         write_preference (str): The option to specify what action to take when you load data from a source file.
             Value can be one of
@@ -516,22 +520,22 @@ class Client:
             >>> client = transfer.Client(project='my-project-id')
             >>> client.s3_to_bq(aws_connection,
             >>>                 bucket_name='my-s3-bucket_name',
-            >>>                 object_name='my-s3-object-name',
+            >>>                 object_or_prefix_name='my-s3-object-name',
             >>>                 bq_table='my-project-id.my-dataset.my-table',
             >>>                 gs_bucket_name='my-gcs-bucket')
         """
 
         # Download S3 file to local
         s3_client = s3.Client(aws_session)
-        local_file = os.path.join('/tmp/', object_name)
-        s3_client.download(bucket_name, object_name, local_file)
+        local_file = os.path.join('/tmp/', object_or_prefix_name)
+        s3_client.download(bucket_name, object_or_prefix_name, local_file)
 
         # Upload local file to GCS
         if not gs_bucket_name:
             logs.client.logger.error("gs_bucket_name must be provided to stage file in GCS before loading to BQ")
             raise ValueError("gs_bucket_name must be provided")
         gs_client = gs.Client(self.project, impersonated_credentials=self.impersonated_credentials)
-        gs_file_name = gs_file_name if gs_file_name else object_name
+        gs_file_name = gs_file_name if gs_file_name else object_or_prefix_name
         gs_client.upload(local_file, gs_bucket_name, gs_file_name)
         gs_uri = f"gs://{gs_bucket_name}/{gs_file_name}"
 

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -1,9 +1,10 @@
 import datetime
 import os
 import re
-import sys
-from typing import List
+from io import BytesIO
+from typing import Tuple
 
+import pandas as pd
 from google.api_core import exceptions
 from google.cloud import bigquery, storage
 
@@ -69,123 +70,95 @@ class Client:
         blobs = storage_client.list_blobs(bucket_name)
         return ['gs://{}/{}'.format(bucket_name, blob.name) for blob in blobs]
 
-    def gs_to_bq(self, gs_uris, table,
-                 write_preference,
-                 auto_detect: bool = True,
-                 skip_leading_rows: bool = True,
-                 separator: str = None,
-                 source_format: str = 'CSV',
-                 schema: List[bigquery.SchemaField] = None,
-                 partition_date: str = None,
-                 partition_field: str = None,
-                 max_bad_records: int = 0):
-        """Load file from Google Storage into the BigQuery table
+    def gs_to_bq(
+            self,
+            business_type,
+            source_type,
+            source,
+            ingestion_type,
+            etl_datetime_utc,
+            dimension,
+            table,
+            file_number=None,
+            write_preference='append',
+            auto_detect=True,
+            schema=None,
+            partition_date=None,
+            partition_field=None,
+            job_config_kwargs=None
+            ) -> Tuple[bool, str]:
+        """
+        - Loads file(s) from Google storage bucket to BigQuery table
+        - Uses the standard naming conventions for bucket, prefix and file name
+          as per documentation here:
+          https://timeoutgroup.atlassian.net/wiki/spaces/TD/pages/3824189448/ELT+Process
+        - Adds etl_datetime_utc column to the dataframe before loading to BigQuery
+        - If multiple files are found, they are all loaded into BigQuery
 
         Args:
-            gs_uris (Union[str, Sequence[str]]):  The Google Storage uri(s) for the file(s). For example: A single file:
-              ``gs://my_bucket_name/my_filename``, multiple files: ``[gs://my_bucket_name/my_first_file,
-              gs://my_bucket_name/my_second_file]``.
+            business_type (str): The business type of the data being ingested. Generally 'markets' or 'web'.
+            source_type (str): The source type of the data being ingested. E.g. 'pos', 'user', 'db', 'tracking', 'ads'
+            source (str): The source of the data being ingested. E.g. 'mariadb_datacafe', 'tenzo', 'facebook'
+            ingestion_type (str): The type of ingestion. Either 'batch' or 'stream'.
+            etl_datetime_utc (str): load datetime string to use in the path
+            dimension (str): The dimension of the data being ingested. E.g. 'audience', 'sales'
             table (str): The BigQuery table name. For example: ``project.dataset.table``.
             write_preference (str): The option to specify what action to take when you load data from a source file.
-            Value can be on of
+              Value can be one of
                                               ``'empty'``: Writes the data only if the table is empty.
                                               ``'append'``: Appends the data to the end of the table.
                                               ``'truncate'``: Erases all existing data in a table before writing the
                                                 new data.
             auto_detect (boolean, Optional):  True if the schema should automatically be detected otherwise False.
-            Defaults to :data:`True`.
-            skip_leading_rows (boolean, Optional):  True to skip the first row of the file otherwise False. Defaults to
-              :data:`True`.
-            separator (str, Optional): The separator. Defaults to :data:`,`
-            source_format (str, Optional): The file format (CSV, JSON, PARQUET or AVRO)
-            compressed (boolean, Optional): True if the file is compressed, defaults ot False
-            schema (tuple): The BigQuery table schema. For example: ``(('first_field','STRING'),('second_field',
-              'STRING'))``
+              Defaults to :data:`True`.
+            schema (List[bigquery.SchemaField], Optional): The BigQuery table schema. Can be a partial schema.
             partition_date (str, Optional): The ingestion date for partitioned destination table. For example:
               ``20210101``. The partition field name will be __PARTITIONTIME
             partition_field (str, Optional): The field on which the destination table is partitioned. The field must be
               a top-level TIMESTAMP or DATE field. Must be used in conjuction with partitioned_date.
               Here partitioned_date will be used to update or alter the table using the partition
-            schema (List[bigquery.SchemaField], Optional): A List of SchemaFields.
-            max_bad_records (int, Optional): The maximum number of rows with errors. Defaults to :data:0
+            job_config_kwargs (dict, Optional): Any additional properties to set for the job config.
 
-        Examples:
-            >>> from to_data_library.data import transfer
-            >>> client = transfer.Client(project='my-project-id')
-            >>> client.gs_to_bq(gs_uris='gs://my-bucket-name/my-filename',table='my-project-id.my_dataset.my_table')
+        Returns:
+            (bool, str): Tuple with success status and message
         """
-        project, dataset_id, table_id = table.split('.')
-        dataset_ref = bigquery.DatasetReference(
-            project=project, dataset_id=dataset_id)
+        bucket_name = self.build_gs_bucket_name(business_type, source_type)
+        prefix = self.build_gs_prefix(source, ingestion_type, etl_datetime_utc, partition_date)
+        file_name = self.build_gs_file_name(source, dimension, etl_datetime_utc, partition_date, file_number)
 
-        job_config = bigquery.LoadJobConfig(
-            autodetect=auto_detect,
-            write_disposition=get_bq_write_disposition(write_preference),
-            allow_quoted_newlines=True,
-            max_bad_records=max_bad_records
-        )
+        gs_client = gs.Client(self.project, impersonated_credentials=self.impersonated_credentials)
 
-        if skip_leading_rows:
-            job_config.skip_leading_rows = 1
+        bucket = gs_client.bucket(bucket_name)
+        blobs = bucket.list_blobs(prefix=prefix)
+        # Get all blobs in the bucket
+        for blob in blobs:
+            # Get all blobs with this prefix and filename
+            if blob.name.startswith(f"{prefix}/{file_name}"):
+                try:
+                    # Load as dataframe
+                    df = self.load_gcs_file_as_dataframe(blob)
+                except Exception as e:
+                    self.logger.error(f"Error loading GCS file {blob.name} as dataframe: {e}")
+                    return False, str(e)
+                # Add metadata: etl_datetime_utc column
+                df['etl_datetime_utc'] = etl_datetime_utc
 
-        if (partition_date and not partition_field):
-            job_config.time_partitioning = bigquery.TimePartitioning(
-                type_=bigquery.TimePartitioningType.DAY)
-            table_id += '${}'.format(partition_date)
-        elif (partition_date and partition_field):
-            job_config.time_partitioning = bigquery.TimePartitioning(
-                type_=bigquery.TimePartitioningType.DAY, field=partition_field)
-            table_id += '${}'.format(partition_date)
-        elif (partition_field and not partition_date and write_preference == 'truncate'):
-            logs.client.logger.error(
-                "Error if partition_field is supplied partitioned_date must also be supplied")
-            sys.exit(1)
+                try:
+                    bq.load_table_from_dataframe(
+                        df,
+                        table,
+                        write_preference,
+                        auto_detect,
+                        schema,
+                        partition_date,
+                        partition_field,
+                        job_config_kwargs
+                        )
+                except Exception as e:
+                    self.logger.error(f"Error loading dataframe to BQ table {table}: {e}")
+                    return False, str(e)
 
-        table_ref = bigquery.TableReference(dataset_ref, table_id=table_id)
-
-        if separator:
-            job_config.field_delimiter = separator
-
-        if schema:
-            if isinstance(schema[0], bigquery.SchemaField):
-                job_config.schema = schema
-            else:
-                job_config.schema = [bigquery.SchemaField(field[0], field[1]) for field in schema]
-
-        # Define the source format
-        if source_format == 'CSV':
-            job_config.source_format = bigquery.SourceFormat.CSV
-        elif source_format == 'JSON':
-            job_config.source_format = bigquery.SourceFormat.NEWLINE_DELIMITED_JSON
-        elif source_format == 'AVRO':
-            job_config.source_format = bigquery.SourceFormat.AVRO
-        elif source_format == 'PARQUET':
-            job_config.source_format = bigquery.SourceFormat.PARQUET
-        else:
-            logs.client.logger.error(
-                f"Invalid SourceFormat entered: {source_format}")
-            sys.exit(1)
-
-        bq_client = bq.Client(project,
-                              impersonated_credentials=self.impersonated_credentials)
-        try:
-            bq_client.create_dataset(dataset_id)
-        except exceptions.Conflict:
-            logs.client.logger.info(
-                'Dataset {} Already exists'.format(dataset_id))
-
-        logs.client.logger.info(
-            'Loading BigQuery table {} from {}'.format(table, gs_uris))
-
-        try:
-            # Start the load job
-            bq_client.load_table_from_uris(
-                gs_uris, table_ref, job_config=job_config
-            )
-
-        except Exception as e:
-            logs.client.logger.error(f"Unexpected error occurred: {e}")
-            return False, str(e)
+        return True, f'Successfully loaded files from gs://{bucket_name}/{prefix}/{file_name} to {table}'
 
     def gs_parquet_to_bq(self, gs_uris, table, write_preference, auto_detect=True,
                          schema=(), partition_date=None, max_bad_records=0):
@@ -385,14 +358,14 @@ class Client:
         """
         return '-'.join([business_type, source_type])
 
-    def build_gs_prefix(self, source, ingestion_type, etl_datetime, partition_name='data') -> str:
+    def build_gs_prefix(self, source, ingestion_type, etl_datetime_utc, partition_date=None) -> str:
         """
-        Builds the gs prefix based on source, ingestion type, etl datetime and partition name
+        Builds the gs prefix based on source, ingestion type, etl datetime and partition date
         Args:
             source (str): The source of the data being ingested. E.g. 'mariadb_datacafe', 'tenzo', 'facebook'
             ingestion_type (str): The type of ingestion. Either 'batch' or 'stream'.
-            etl_datetime (str): load datetime string to use in the path
-            partition_name (str): name of the partition, default 'data'
+            etl_datetime_utc (str): load datetime string to use in the path
+            partition_date (str): date of the partition if one exists
         Returns:
             str: The gs prefix
         Example:
@@ -400,17 +373,20 @@ class Client:
             >>> client = transfer.Client(project='my-project-id')
             >>> prefix = client.build_gs_prefix('tenzo', 'batch', '20250102_120000', '2021-01-01')
         """
-        return '/'.join([source, ingestion_type, partition_name, etl_datetime])
+        parts = [source, ingestion_type]
+        if partition_date:
+            parts.append(partition_date)
+        parts.append(etl_datetime_utc)
+        return '/'.join(parts)
 
-    def build_gs_file_name(self, source, dimension, partition_date, etl_datetime, file_number) -> str:
+    def build_gs_file_name(self, source, dimension, etl_datetime_utc, partition_date=None, file_number=None) -> str:
         """
         Builds the gs file name based on source, dimension, partition date, etl datetime and file number
         Args:
             source (str): The source of the data being ingested. E.g. 'mariadb_datacafe', 'tenzo', 'facebook'
             dimension (str): The dimension of the data being ingested. E.g. 'audience', 'sales'
+            etl_datetime_utc (str): load datetime string to use in the path
             partition_date (str): The partition date, e.g. '2021-01-01'
-            etl_datetime (str): load datetime string to use in the path
-            file_number (str): The file number, e.g. '000'
         Returns:
             str: The gs file name
         Example:
@@ -418,15 +394,21 @@ class Client:
             >>> client = transfer.Client(project='my-project-id')
             >>> file_name = client.build_gs_file_name('tenzo', 'sales', '2021-01-01', '20250102_120000', '000')
         """
-        return '_'.join([source, dimension, partition_date, etl_datetime, file_number])
+        parts = [source, dimension]
+        if partition_date:
+            parts.append(partition_date)
+        parts.append(etl_datetime_utc)
+        if file_number:
+            parts.append(file_number)
+        return '_'.join(parts)
 
-    def build_gs_metadata(self, s3_bucket_name, s3_object_name, etl_datetime, repo_name) -> dict:
+    def build_gs_metadata(self, s3_bucket_name, s3_object_name, etl_datetime_utc, repo_name) -> dict:
         """
         Builds the gs metadata based on s3 bucket name, s3 object name and etl datetime
         Args:
             s3_bucket_name (str): s3 bucket name
             s3_object_name (str): s3 object name
-            etl_datetime (str): load datetime string to use in the path
+            etl_datetime_utc (str): load datetime string to use in the path
             repo_name (str): The name of the repo that is running the ingestion
         Returns:
             dict: The gs metadata
@@ -438,7 +420,7 @@ class Client:
         return {
             's3_bucket_name': s3_bucket_name,
             's3_object_name': s3_object_name,
-            'etl_datetime': etl_datetime,
+            'etl_datetime_utc': etl_datetime_utc,
             'repo_name': repo_name
         }
 
@@ -456,9 +438,9 @@ class Client:
             file_number='000',
             wildcard=None,
             additional_metadata=None,
-            partition_name='data',
-            etl_datetime=None
-            ) -> (bool, str):
+            partition_date=None,
+            etl_datetime_utc=None
+            ) -> Tuple[bool, str]:
         """
         - Exports file(s) from S3 bucket to Google storage bucket
         - Enforces the use of the standard naming conventions for bucket, prefix, file name and metadata
@@ -479,7 +461,7 @@ class Client:
             file_number (str, Optional): The file number. Defaults to '000'.
             wildcard (str): regex wildcard (default '.*')
             additional_metadata (dict): custom metadata to set on the GS object
-            partition_name (str): name of the partition, default 'data'
+            partition_date (str): date of the partition if one exists
             etl_datetime (str): load datetime string to use in the path and file name
         Returns:
             (bool, str): Tuple with success status and message
@@ -495,15 +477,14 @@ class Client:
             >>>                                 source='tenzo',
             >>>                                 dimension='sales')
         """
-        if not etl_datetime:
-            etl_datetime = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
+        if not etl_datetime_utc:
+            etl_datetime_utc = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
 
-        # Build the GS bucket name, prefix, file name and metadata
+        # Build the GS bucket name, prefix and metadata
         gs_bucket_name = self.build_gs_bucket_name(business_type, source_type)
-        gs_prefix = self.build_gs_prefix(source, ingestion_type, etl_datetime, partition_name)
-        gs_file_name = self.build_gs_file_name(source, dimension, partition_name, etl_datetime)
+        gs_prefix = self.build_gs_prefix(source, ingestion_type, etl_datetime_utc, partition_date)
 
-        metadata = self.build_gs_metadata(s3_bucket_name, s3_object_or_prefix_name, etl_datetime, repo_name)
+        metadata = self.build_gs_metadata(s3_bucket_name, s3_object_or_prefix_name, etl_datetime_utc, repo_name)
         if additional_metadata:
             metadata.update(additional_metadata)
 
@@ -531,7 +512,7 @@ class Client:
 
             # Try to download the file to local
             try:
-                gs_file_name = self.build_gs_file_name(source, dimension, partition_name, etl_datetime, file_number)
+                gs_file_name = self.build_gs_file_name(source, dimension, etl_datetime_utc, partition_date, file_number)
                 gs_file_path = '/'.join([gs_prefix, gs_file_name])
                 local_file = s3_client.download(s3_bucket_name, s3_file)
                 logs.client.logger.info(f'Successfully downloaded {local_file} to local')
@@ -586,3 +567,27 @@ class Client:
                     s3_files.append(obj.get('Key'))
 
         return s3_files
+
+    def load_gcs_file_as_dataframe(self, blob) -> pd.DataFrame:
+        """
+        Loads a GCS blob into a pandas dataframe
+        Args:
+            blob: The GCS blob object
+        Returns:
+            pd.DataFrame: The pandas dataframe
+        Example:
+            >>> from to_data_library.data import transfer
+            >>> client = transfer.Client(project='my-project-id')
+            >>> gs_client = gs.Client(project='my-project-id')
+            >>> bucket = gs_client.bucket('my-bucket-name')
+            >>> blob = bucket.blob('my-blob-name')
+            >>> df = client.load_gcs_file_as_dataframe(blob)
+        """
+        file_type = blob.name.split('.')[-1]
+        data = BytesIO(blob.download_as_bytes())
+        if file_type == 'csv':
+            return pd.read_csv(data)
+        elif file_type == 'json':
+            return pd.read_json(data, lines=True)
+        else:
+            raise ValueError(f"Unsupported file type: {file_type}")

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -3,7 +3,7 @@ import os
 import re
 from io import BytesIO
 from pathlib import Path
-from typing import List, Tuple
+from typing import Tuple
 
 import pandas as pd
 from google.api_core import exceptions
@@ -83,8 +83,8 @@ class Client:
             file_number=None,
             write_preference='append',
             auto_detect=True,
-            max_bad_records: int = 0,
-            schema_update_options: List[bigquery.SchemaUpdateOption] = None,
+            max_bad_records=0,
+            schema_update_options=None,
             schema=None,
             data_date=None,
             partition_field=None,

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -84,7 +84,7 @@ class Client:
             write_preference='append',
             auto_detect=True,
             schema=None,
-            partition_date=None,
+            data_date=None,
             partition_field=None,
             job_config_kwargs=None,
             transform_function=None
@@ -114,8 +114,8 @@ class Client:
             auto_detect (boolean, Optional):  True if the schema should automatically be detected otherwise False.
               Defaults to :data:`True`.
             schema (List[bigquery.SchemaField], Optional): The BigQuery table schema. Can be a partial schema.
-            partition_date (str, Optional): partition_date (str): date of the partition if one exists
-              - this refers to the partition part of the prefix
+            data_date (str, Optional): effective date of the data if one exists
+              - this refers to the 'date' part of the prefix
             partition_field (str, Optional): The field on which the destination table is partitioned. The field must be
               a top-level TIMESTAMP or DATE field. Must be used in conjuction with partitioned_date.
               Here partitioned_date will be used to update or alter the table using the partition
@@ -128,8 +128,8 @@ class Client:
         """
 
         bucket_name = self.build_gs_bucket_name(business_type, source_type)
-        prefix = self.build_gs_prefix(source, ingestion_type, etl_datetime_utc, partition_date)
-        file_name = self.build_gs_file_name(source, dimension, etl_datetime_utc, partition_date, file_number)
+        prefix = self.build_gs_prefix(source, ingestion_type, etl_datetime_utc, data_date)
+        file_name = self.build_gs_file_name(source, dimension, etl_datetime_utc, data_date, file_number)
 
         gs_client = gs.Client(self.project, impersonated_credentials=self.impersonated_credentials)
         bq_client = bq.Client(self.project, impersonated_credentials=self.impersonated_credentials)
@@ -402,14 +402,14 @@ class Client:
         """
         return '-'.join([self.project, business_type, source_type])
 
-    def build_gs_prefix(self, source, ingestion_type, etl_datetime_utc, partition_date=None) -> str:
+    def build_gs_prefix(self, source, ingestion_type, etl_datetime_utc, data_date=None) -> str:
         """
-        Builds the gs prefix based on source, ingestion type, etl datetime and partition date
+        Builds the gs prefix based on source, ingestion type, etl datetime and data date
         Args:
             source (str): The source of the data being ingested. E.g. 'mariadb_datacafe', 'tenzo', 'facebook'
             ingestion_type (str): The type of ingestion. Either 'batch' or 'stream'.
             etl_datetime_utc (str): load datetime string to use in the path
-            partition_date (str): date of the partition if one exists
+            data_date (str): effective date of the data if one exists
         Returns:
             str: The gs prefix
         Example:
@@ -418,8 +418,8 @@ class Client:
             >>> prefix = client.build_gs_prefix('tenzo', 'batch', '20250102_120000', '2021-01-01')
         """
         parts = [source, ingestion_type]
-        if partition_date:
-            parts.append(partition_date)
+        if data_date:
+            parts.append(data_date)
         parts.append(etl_datetime_utc)
         return '/'.join(parts)
 
@@ -428,17 +428,17 @@ class Client:
             source,
             dimension,
             etl_datetime_utc,
-            partition_date=None,
+            data_date=None,
             file_number=None,
             file_extension=None
     ) -> str:
         """
-        Builds the gs file name based on source, dimension, partition date, etl datetime and file number
+        Builds the gs file name based on source, dimension, data date, etl datetime and file number
         Args:
             source (str): The source of the data being ingested. E.g. 'mariadb_datacafe', 'tenzo', 'facebook'
             dimension (str): The dimension of the data being ingested. E.g. 'audience', 'sales'
             etl_datetime_utc (str): load datetime string to use in the path
-            partition_date (str): The partition date, e.g. '2021-01-01'
+            data_date (str): The effective data date, e.g. '2021-01-01'
             file_number (str): The file number
             file_extension (str): The file extension without the leading dot, e.g. 'csv', 'parquet
         Returns:
@@ -449,8 +449,8 @@ class Client:
             >>> file_name = client.build_gs_file_name('tenzo', 'sales', '2021-01-01', '20250102_120000', '000')
         """
         parts = [source, dimension]
-        if partition_date:
-            parts.append(partition_date)
+        if data_date:
+            parts.append(data_date)
         parts.append(etl_datetime_utc)
         if file_number:
             parts.append(file_number)
@@ -494,7 +494,7 @@ class Client:
             ingestion_type='batch',
             file_number='000',
             wildcard=None,
-            partition_date=None,
+            data_date=None,
             etl_datetime_utc=None
             ) -> Tuple[bool, str]:
         """
@@ -517,7 +517,8 @@ class Client:
             file_number (str, Optional): The file number. Defaults to '000'.
             wildcard (str): regex wildcard (default '.*')
             additional_metadata (dict): custom metadata to set on the GS object
-            partition_date (str): date of the partition if one exists - this determines the partition part of the prefix
+            data_date (str): effective date of the data set if one exists
+              - this determines the 'date' part of the prefix
             etl_datetime (str): load datetime string to use in the path and file name
         Returns:
             (bool, str): Tuple with success status and message
@@ -546,7 +547,7 @@ class Client:
 
         # Build the GS bucket name, prefix and metadata
         gs_bucket_name = self.build_gs_bucket_name(business_type, source_type)
-        gs_prefix = self.build_gs_prefix(source, ingestion_type, etl_datetime_utc, partition_date)
+        gs_prefix = self.build_gs_prefix(source, ingestion_type, etl_datetime_utc, data_date)
 
         metadata = self.build_gs_metadata(s3_bucket_name, s3_object_or_prefix_name, etl_datetime_utc, repo_name)
 
@@ -587,7 +588,7 @@ class Client:
                     source,
                     dimension,
                     etl_datetime_utc,
-                    partition_date,
+                    data_date,
                     file_number,
                     s3_file_extension
                 )

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -555,7 +555,7 @@ class Client:
         # Ensure no underscores in source or dimension
         for element in [source, dimension]:
             if '_' in element:
-                return False,  f"Error: {element} must not contain underscores."
+                return False, f"Error: {element} must not contain underscores."
 
         if not etl_datetime_utc:
             etl_datetime_utc = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -420,24 +420,26 @@ class Client:
         """
         return '_'.join([source, dimension, partition_date, etl_datetime, file_number])
 
-    def build_gs_metadata(self, s3_bucket_name, s3_object_name, etl_datetime) -> dict:
+    def build_gs_metadata(self, s3_bucket_name, s3_object_name, etl_datetime, repo_name) -> dict:
         """
         Builds the gs metadata based on s3 bucket name, s3 object name and etl datetime
         Args:
             s3_bucket_name (str): s3 bucket name
             s3_object_name (str): s3 object name
             etl_datetime (str): load datetime string to use in the path
+            repo_name (str): The name of the repo that is running the ingestion
         Returns:
             dict: The gs metadata
         Example:
             >>> from to_data_library.data import transfer
             >>> client = transfer.Client(project='my-project-id')
-            >>> metadata = client.build_gs_metadata('my-s3-bucket', 'my-s3-object', '20250102_120000')
+            >>> metadata = client.build_gs_metadata('my-s3-bucket', 'my-s3-object', '20250102_120000', 'da-my-repo')
         """
         return {
             's3_bucket_name': s3_bucket_name,
             's3_object_name': s3_object_name,
-            'etl_datetime': etl_datetime
+            'etl_datetime': etl_datetime,
+            'repo_name': repo_name
         }
 
     def s3_to_gs(
@@ -449,6 +451,7 @@ class Client:
             source_type,
             source,
             dimension,
+            repo_name='Unknown',
             ingestion_type='batch',
             file_number='000',
             wildcard=None,
@@ -471,6 +474,7 @@ class Client:
             source_type (str): The source type of the data being ingested. E.g. 'pos', 'user', 'db', 'tracking', 'ads'
             source (str): The source of the data being ingested. E.g. 'mariadb_datacafe', 'tenzo', 'facebook'
             dimension (str): The dimension of the data being ingested. E.g. 'audience', 'sales'
+            repo_name (str, Optional): The name of the repo that is running the ingestion. Defaults to 'Unknown'.
             ingestion_type (str, Optional): The type of ingestion. Either 'batch' or 'stream'. Defaults to 'batch'.
             file_number (str, Optional): The file number. Defaults to '000'.
             wildcard (str): regex wildcard (default '.*')
@@ -499,7 +503,7 @@ class Client:
         gs_prefix = self.build_gs_prefix(source, ingestion_type, etl_datetime, partition_name)
         gs_file_name = self.build_gs_file_name(source, dimension, partition_name, etl_datetime)
 
-        metadata = self.build_gs_metadata(s3_bucket_name, s3_object_or_prefix_name, etl_datetime)
+        metadata = self.build_gs_metadata(s3_bucket_name, s3_object_or_prefix_name, etl_datetime, repo_name)
         if additional_metadata:
             metadata.update(additional_metadata)
 

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -533,7 +533,7 @@ class Client:
             wildcard (str): regex wildcard (default '.*')
             data_date (str): effective date of the data set if one exists
               - this determines the 'date' part of the prefix
-            etl_datetime (str): load datetime string to use in the path and file name
+            etl_datetime_utc (str): load datetime string to use in the path and file name
         Returns:
             (bool, str): Tuple with success status and message
 

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -531,7 +531,6 @@ class Client:
             ingestion_type (str, Optional): The type of ingestion. Either 'batch' or 'stream'. Defaults to 'batch'.
             file_number (str, Optional): The file number. Defaults to '000'.
             wildcard (str): regex wildcard (default '.*')
-            additional_metadata (dict): custom metadata to set on the GS object
             data_date (str): effective date of the data set if one exists
               - this determines the 'date' part of the prefix
             etl_datetime (str): load datetime string to use in the path and file name

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -3,7 +3,7 @@ import os
 import re
 from io import BytesIO
 from pathlib import Path
-from typing import Tuple
+from typing import List, Tuple
 
 import pandas as pd
 from google.api_core import exceptions
@@ -83,6 +83,8 @@ class Client:
             file_number=None,
             write_preference='append',
             auto_detect=True,
+            max_bad_records: int = 0,
+            schema_update_options: List[bigquery.SchemaUpdateOption] = None,
             schema=None,
             data_date=None,
             partition_field=None,
@@ -113,6 +115,12 @@ class Client:
                                                 new data.
             auto_detect (boolean, Optional):  True if the schema should automatically be detected otherwise False.
               Defaults to :data:`True`.
+            max_bad_records (int, Optional): The maximum number of rows with errors allowed when loading data.
+            schema_update_options (List[bigquery.SchemaUpdateOption], Optional): Specifies the schema update options
+              to use when loading data into a table. The schema_update_options property
+              allows the schema of the destination table to be updated as a side effect of loading
+              new data. The schema_update_options can only be used when write_preference is set to 'append' or
+              'truncate'.
             schema (List[bigquery.SchemaField], Optional): The BigQuery table schema. Can be a partial schema.
             data_date (str, Optional): effective date of the data if one exists
               - this refers to the 'date' part of the prefix
@@ -130,6 +138,13 @@ class Client:
         bucket_name = self.build_gs_bucket_name(business_type, source_type)
         prefix = self.build_gs_prefix(source, ingestion_type, etl_datetime_utc, data_date)
         file_name = self.build_gs_file_name(source, dimension, etl_datetime_utc, data_date, file_number)
+
+        if job_config_kwargs is None:
+            job_config_kwargs = {}
+        if max_bad_records > 0:
+            job_config_kwargs['max_bad_records'] = max_bad_records
+        if schema_update_options:
+            job_config_kwargs['schema_update_options'] = schema_update_options
 
         gs_client = gs.Client(self.project, impersonated_credentials=self.impersonated_credentials)
         bq_client = bq.Client(self.project, impersonated_credentials=self.impersonated_credentials)
@@ -626,9 +641,9 @@ class Client:
         Returns:
             list: List of keys in that bucket that match the desired prefix
         """
-        s3_client_boto = aws_session.client("s3")
+        s3_client_boto = aws_session.client('s3')
         s3_files = []
-        paginator = s3_client_boto.get_paginator("list_objects_v2")
+        paginator = s3_client_boto.get_paginator('list_objects_v2')
 
         regex = re.compile(wildcard)
 

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -455,7 +455,7 @@ class Client:
             etl_datetime_utc (str): load datetime string to use in the path
             data_date (str): The effective data date, e.g. '2021-01-01'
             file_number (str): The file number
-            file_extension (str): The file extension without the leading dot, e.g. 'csv', 'parquet
+            file_extension (str): The file extension without the leading dot, e.g. 'csv', 'parquet'
         Returns:
             str: The gs file name
         Example:

--- a/to_data_library/data/transfer.py
+++ b/to_data_library/data/transfer.py
@@ -86,7 +86,8 @@ class Client:
             schema=None,
             partition_date=None,
             partition_field=None,
-            job_config_kwargs=None
+            job_config_kwargs=None,
+            transform_function=None
             ) -> Tuple[bool, str]:
         """
         - Loads file(s) from Google storage bucket to BigQuery table
@@ -113,12 +114,14 @@ class Client:
             auto_detect (boolean, Optional):  True if the schema should automatically be detected otherwise False.
               Defaults to :data:`True`.
             schema (List[bigquery.SchemaField], Optional): The BigQuery table schema. Can be a partial schema.
-            partition_date (str, Optional): The ingestion date for partitioned destination table. For example:
-              ``20210101``. The partition field name will be __PARTITIONTIME
+            partition_date (str, Optional): partition_date (str): date of the partition if one exists
+              - this refers to the partition part of the prefix
             partition_field (str, Optional): The field on which the destination table is partitioned. The field must be
               a top-level TIMESTAMP or DATE field. Must be used in conjuction with partitioned_date.
               Here partitioned_date will be used to update or alter the table using the partition
             job_config_kwargs (dict, Optional): Any additional properties to set for the job config.
+            transform_function (Callable, Optional): A function that takes a pandas DataFrame as input and
+              returns a transformed DataFrame.
 
         Returns:
             (bool, str): Tuple with success status and message
@@ -129,37 +132,75 @@ class Client:
         file_name = self.build_gs_file_name(source, dimension, etl_datetime_utc, partition_date, file_number)
 
         gs_client = gs.Client(self.project, impersonated_credentials=self.impersonated_credentials)
+        bq_client = bq.Client(self.project, impersonated_credentials=self.impersonated_credentials)
 
-        bucket = gs_client.get_bucket(bucket_name)
-        blobs = bucket.list_blobs(prefix=prefix)
+        # Get all blobs in the bucket matching the file name
+        blobs = list(gs_client.get_blobs(bucket_name, prefix=prefix))
+        blobs = [blob for blob in blobs if blob.name.startswith(f"{prefix}/{file_name}")]
 
-        # Get all blobs in the bucket
+        logs.client.logger.info(f"Found {len(blobs)} files in gs://{bucket_name}/{prefix}/ matching {file_name}")
+
         for blob in blobs:
-            # Get all blobs with this prefix and filename
-            if blob.name.startswith(f"{prefix}/{file_name}"):
-                try:
-                    # Load as dataframe
-                    df = self.load_gcs_file_as_dataframe(blob)
-                except Exception as e:
-                    self.logger.error(f"Error loading GCS file {blob.name} as dataframe: {e}")
-                    return False, str(e)
-                # Add metadata: etl_datetime_utc column
-                df['etl_datetime_utc'] = etl_datetime_utc
+            logs.client.logger.info(f"Loading file {blob.name}...")
+            try:
+                # Load as dataframe
+                df = self.load_gcs_file_as_dataframe(blob)
+            except Exception as e:
+                logs.client.logger.error(f"Error loading GCS file {blob.name} as dataframe: {e}")
+                return False, str(e)
+            # Add metadata: etl_datetime_utc column
+            df['etl_datetime_utc'] = etl_datetime_utc
 
+            if transform_function:
                 try:
-                    bq.load_table_from_dataframe(
-                        df,
+                    df = transform_function(df)
+                except Exception as e:
+                    logs.client.logger.error(f"Error applying transform function to dataframe from {blob.name}: {e}")
+                    return False, str(e)
+
+            dfs = []
+            if partition_field:
+
+                # Ensure partition field is in the dataframe
+                if partition_field not in df.columns:
+                    logs.client.logger.error(
+                        f"Partition field {partition_field} not found in dataframe columns")
+                    return False, f"Partition field {partition_field} not found in dataframe columns"
+
+                # Split df into separate dataframes for each partition date
+                partition_dates = df[partition_field].unique()
+                logs.client.logger.info(f"Found {len(partition_dates)} partition dates.")
+                logs.client.logger.info("Splitting dataframe into separate partitions for loading.")
+                for date in partition_dates:
+                    partition_df = df[df[partition_field] == date]
+                    try:
+                        part_date = date.strftime('%Y%m%d')
+                    except Exception as e:
+                        logs.client.logger.error(f"Error formatting partition date {date}: {e}")
+                        return (
+                            False,
+                            f"Error formatting partition date {date}."
+                            f" Ensure partition field {partition_field} contains all valid date or datetime values."
+                        )
+                    dfs.append({'df': partition_df, 'partition_date': part_date})
+            else:
+                dfs.append({'df': df, 'partition_date': None})
+
+            try:
+                for df in dfs:
+                    bq_client.load_table_from_dataframe(
+                        df['df'],
                         table,
                         write_preference,
                         auto_detect,
                         schema,
-                        partition_date,
+                        df['partition_date'],
                         partition_field,
                         job_config_kwargs
                         )
-                except Exception as e:
-                    self.logger.error(f"Error loading dataframe to BQ table {table}: {e}")
-                    return False, str(e)
+            except Exception as e:
+                logs.client.logger.error(f"Error loading dataframe to BQ table {table}: {e}")
+                return False, str(e)
 
         return True, f'Successfully loaded files from gs://{bucket_name}/{prefix}/{file_name} to {table}'
 
@@ -476,7 +517,7 @@ class Client:
             file_number (str, Optional): The file number. Defaults to '000'.
             wildcard (str): regex wildcard (default '.*')
             additional_metadata (dict): custom metadata to set on the GS object
-            partition_date (str): date of the partition if one exists
+            partition_date (str): date of the partition if one exists - this determines the partition part of the prefix
             etl_datetime (str): load datetime string to use in the path and file name
         Returns:
             (bool, str): Tuple with success status and message


### PR DESCRIPTION
See [JIRA ticket](https://timeoutgroup.atlassian.net/jira/software/c/projects/DSS/boards/72?selectedIssue=DSS-3346) for more info of what is required.

This updates the to-data-library to provide methods s3_to_gs and gs_to_bq which enforce the use of our new GCS file structure. I have also update the bq method load_table_from_dataframe to handle the case where a file has multiple partition dates and needs to be separated into individual loads (as per the case with Ozone which has 7 days' data per file).

I have tested this as past of [DSS-3169](https://timeoutgroup.atlassian.net/browse/DSS-3169?focusedCommentId=265783).

Unit tests still need to be added and will be done as part of a future PR before the JIRA ticket is closed.

The PR is quite large, so I'm happy to discuss with the reviewer on a call if preferred.

[DSS-3169]: https://timeoutgroup.atlassian.net/browse/DSS-3169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


Here's a screenshot of the tests passing:
<img width="1908" height="64" alt="image" src="https://github.com/user-attachments/assets/3652a8f3-b3ae-49f5-928a-aa0cdae42199" />

Note: we could do with more tests, especially on error handling, however I'm reluctant to add any at the mo as the PR is already big.