### PR TITLE
DSS-3398: make impersonated_credentials non-optional

### DIFF
--- a/tests/test_gs.py
+++ b/tests/test_gs.py
@@ -15,42 +15,42 @@ def tearDownModule():
 
 def gzip_bytes_from_str(s):
     buf = BytesIO()
-    with gzip.GzipFile(fileobj=buf, mode='wb') as f:
-        f.write(s.encode('utf-8'))
+    with gzip.GzipFile(fileobj=buf, mode="wb") as f:
+        f.write(s.encode("utf-8"))
     buf.seek(0)
     return buf.getvalue()
 
 
 class TestGS(unittest.TestCase):
-    @mock.patch('to_data_library.data.gs.storage.Client')
+    @mock.patch("to_data_library.data.gs.storage.Client")
     def test_download(self, mock_storage_client):
         mock_client_instance = mock_storage_client.return_value
-        test_client = Client(project='fake_project')
+        test_client = Client(project="fake_project", impersonated_credentials="mr.sandman")
         mock_client_instance.download_blob_to_file = mock.Mock()
 
-        gs_uri = 'gs://fake_bucket/fake_file.csv'
+        gs_uri = "gs://fake_bucket/fake_file.csv"
         test_client.download(gs_uri)
 
         mock_client_instance.download_blob_to_file.assert_called_once()
         called_args = mock_client_instance.download_blob_to_file.call_args[0]
         self.assertEqual(called_args[0], gs_uri)
-        self.assertTrue(hasattr(called_args[1], 'write'))
+        self.assertTrue(hasattr(called_args[1], "write"))
 
-    @mock.patch('to_data_library.data.gs.storage')
+    @mock.patch("to_data_library.data.gs.storage")
     def test_upload(self, mock_storage):
         mock_client = mock_storage.Client.return_value
         mock_bucket = Mock()
         mock_client.bucket.return_value = mock_bucket
 
-        test_client = Client(project='fake_project')
+        test_client = Client(project="fake_project", impersonated_credentials="mr.sandman")
 
-        test_client.upload('tests/data/sample.csv', 'fake_bucket')
-        mock_bucket.blob.assert_called_with('sample.csv')
+        test_client.upload("tests/data/sample.csv", "fake_bucket")
+        mock_bucket.blob.assert_called_with("sample.csv")
 
-        test_client.upload('tests/data/sample.csv', 'fake_bucket', 'new_name')
-        mock_bucket.blob.assert_called_with('new_name')
+        test_client.upload("tests/data/sample.csv", "fake_bucket", "new_name")
+        mock_bucket.blob.assert_called_with("new_name")
 
-    @mock.patch('to_data_library.data.gs.storage')
+    @mock.patch("to_data_library.data.gs.storage")
     def test_convert_json_array_to_ndjson_array_input(self, mock_storage):
         mock_client = mock_storage.Client.return_value
         mock_bucket = MagicMock()
@@ -67,14 +67,12 @@ class TestGS(unittest.TestCase):
 
         mock_bucket.blob.side_effect = [input_blob, output_blob]
 
-        test_client = Client(project='fake_project')
+        test_client = Client(project="fake_project", impersonated_credentials="mr.sandman")
         test_client.storage_client = mock_client
         test_client.logger = Mock()
 
         test_client.convert_json_array_to_ndjson(
-            bucket_name='fake_bucket',
-            input_gz_file='input.gz',
-            output_file='output.ndjson'
+            bucket_name="fake_bucket", input_gz_file="input.gz", output_file="output.ndjson"
         )
 
         args, kwargs = output_blob.upload_from_file.call_args
@@ -82,7 +80,7 @@ class TestGS(unittest.TestCase):
         self.assertIn('{"a": 1}', uploaded_content)
         self.assertIn('{"b": 2}', uploaded_content)
 
-    @mock.patch('to_data_library.data.gs.storage')
+    @mock.patch("to_data_library.data.gs.storage")
     def test_convert_json_array_to_ndjson_ndjson_input(self, mock_storage):
         mock_client = mock_storage.Client.return_value
         mock_bucket = MagicMock()
@@ -99,14 +97,12 @@ class TestGS(unittest.TestCase):
 
         mock_bucket.blob.side_effect = [input_blob, output_blob]
 
-        test_client = Client(project='fake_project')
+        test_client = Client(project="fake_project", impersonated_credentials="mr.sandman")
         test_client.storage_client = mock_client
         test_client.logger = Mock()
 
         test_client.convert_json_array_to_ndjson(
-            bucket_name='fake_bucket',
-            input_gz_file='ndjson_input.gz',
-            output_file='ndjson_output.ndjson'
+            bucket_name="fake_bucket", input_gz_file="ndjson_input.gz", output_file="ndjson_output.ndjson"
         )
 
         args, kwargs = output_blob.upload_from_file.call_args
@@ -114,7 +110,7 @@ class TestGS(unittest.TestCase):
         self.assertIn('{"x": 10}', uploaded)
         self.assertIn('{"y": 20}', uploaded)
 
-    @mock.patch('to_data_library.data.gs.storage')
+    @mock.patch("to_data_library.data.gs.storage")
     def test_convert_json_array_to_ndjson_malformed_line(self, mock_storage):
         mock_client = mock_storage.Client.return_value
         mock_bucket = MagicMock()
@@ -131,24 +127,22 @@ class TestGS(unittest.TestCase):
 
         mock_bucket.blob.side_effect = [input_blob, output_blob]
 
-        test_client = Client(project='fake_project')
+        test_client = Client(project="fake_project", impersonated_credentials="mr.sandman")
         test_client.storage_client = mock_client
         test_client.logger = Mock()
 
         test_client.convert_json_array_to_ndjson(
-            bucket_name='fake_bucket',
-            input_gz_file='bad_file.gz',
-            output_file='cleaned.ndjson'
+            bucket_name="fake_bucket", input_gz_file="bad_file.gz", output_file="cleaned.ndjson"
         )
 
         args, kwargs = output_blob.upload_from_file.call_args
         result = args[0].read().decode()
         self.assertIn('{"valid": 1}', result)
         self.assertIn('{"also": "valid"}', result)
-        self.assertNotIn('bad_json', result)
+        self.assertNotIn("bad_json", result)
         test_client.logger.warning.assert_called()
 
-    @mock.patch('to_data_library.data.gs.storage')
+    @mock.patch("to_data_library.data.gs.storage")
     def test_convert_json_array_to_ndjson_overwrites_existing(self, mock_storage):
         mock_client = mock_storage.Client.return_value
         mock_bucket = MagicMock()
@@ -162,14 +156,12 @@ class TestGS(unittest.TestCase):
 
         mock_bucket.blob.side_effect = [input_blob, output_blob]
 
-        test_client = Client(project='fake_project')
+        test_client = Client(project="fake_project", impersonated_credentials="mr.sandman")
         test_client.storage_client = mock_client
         test_client.logger = Mock()
 
         test_client.convert_json_array_to_ndjson(
-            bucket_name='fake_bucket',
-            input_gz_file='input.gz',
-            output_file='output.ndjson'
+            bucket_name="fake_bucket", input_gz_file="input.gz", output_file="output.ndjson"
         )
 
         output_blob.delete.assert_called_once()

--- a/to_data_library/data/gs.py
+++ b/to_data_library/data/gs.py
@@ -18,10 +18,9 @@ class Client:
         impersonated credentials object that will be used to authenticate the client
     """
 
-    def __init__(self, project, impersonated_credentials=None):
+    def __init__(self, project, impersonated_credentials):
         self.project = project
-        self.storage_client = storage.Client(project=self.project,
-                                             credentials=impersonated_credentials)
+        self.storage_client = storage.Client(project=self.project, credentials=impersonated_credentials)
 
     def download(self, gs_uri, destination_file_name=None):
         """Download from Google Storage to local.
@@ -32,9 +31,9 @@ class Client:
             If not provided, destination_file_name will be name of file in GCS.
         """
         if not destination_file_name:
-            destination_file_name = gs_uri.split('/')[-1]
+            destination_file_name = gs_uri.split("/")[-1]
 
-        with open(destination_file_name, 'wb') as file_obj:
+        with open(destination_file_name, "wb") as file_obj:
             self.storage_client.download_blob_to_file(gs_uri, file_obj)
 
     def upload(self, source_file_name, bucket_name, blob_name=None, metadata=None):
@@ -46,7 +45,7 @@ class Client:
             blob_name (str): The destination file name in the bucket, if not provided source file name will be used.
         """
         if not blob_name:
-            blob_name = source_file_name.split('/')[-1]
+            blob_name = source_file_name.split("/")[-1]
 
         blob = self.storage_client.bucket(bucket_name).blob(blob_name)
         blob.metadata = metadata
@@ -65,7 +64,7 @@ class Client:
         blobs = self.storage_client.list_blobs(bucket_name, prefix=prefix)
         return blobs
 
-    def list_bucket_uris(self, bucket_name, file_type='csv', prefix=None):
+    def list_bucket_uris(self, bucket_name, file_type="csv", prefix=None):
         """Lists the files in a bucket
 
         Args:
@@ -87,7 +86,7 @@ class Client:
             bucket_name (str):  The Google Storage bucket name (no 'gs://' prefix).
         """
 
-        self.storage_client.create_bucket(bucket_name, location='EU')
+        self.storage_client.create_bucket(bucket_name, location="EU")
 
     def convert_json_array_to_ndjson(self, bucket_name, input_gz_file, output_file):
         """Converts a gzip json file to ndjson with minimal memory and storage usage.
@@ -106,26 +105,26 @@ class Client:
         input_stream = BytesIO(input_blob.download_as_bytes())
         output_stream = BytesIO()
 
-        with gzip.GzipFile(fileobj=input_stream, mode='rb') as gz_file:
-            with TextIOWrapper(gz_file, encoding='utf-8') as text_file:
+        with gzip.GzipFile(fileobj=input_stream, mode="rb") as gz_file:
+            with TextIOWrapper(gz_file, encoding="utf-8") as text_file:
                 try:
                     # Try to treat file as a JSON array
                     json_data = json.load(text_file)
                     for json_obj in json_data:
-                        output_stream.write(ndjson.dumps([json_obj]).encode('utf-8') + b'\n')
+                        output_stream.write(ndjson.dumps([json_obj]).encode("utf-8") + b"\n")
                 except json.JSONDecodeError:
                     # Rewind stream and treat as line-delimited JSON (NDJSON)
                     input_stream.seek(0)
-                    with gzip.GzipFile(fileobj=input_stream, mode='rb') as gz_file_reopened:
-                        with TextIOWrapper(gz_file_reopened, encoding='utf-8') as line_file:
+                    with gzip.GzipFile(fileobj=input_stream, mode="rb") as gz_file_reopened:
+                        with TextIOWrapper(gz_file_reopened, encoding="utf-8") as line_file:
                             for line in line_file:
                                 try:
                                     json_obj = json.loads(line)
-                                    output_stream.write(ndjson.dumps([json_obj]).encode('utf-8') + b'\n')
+                                    output_stream.write(ndjson.dumps([json_obj]).encode("utf-8") + b"\n")
                                 except json.JSONDecodeError:
                                     self.logger.warning("Skipping malformed line in file: %s", input_gz_file)
 
         output_stream.seek(0)
-        target_blob.upload_from_file(output_stream, content_type='application/x-ndjson')
+        target_blob.upload_from_file(output_stream, content_type="application/x-ndjson")
 
         logs.client.logger.info(f"Converted and uploaded NDJSON file to: gs://{bucket_name}/{output_file}")


### PR DESCRIPTION
* The only change is line 21 (the rest is formatting I'm afraid)
* This may be a breaking change (it's very unusual to make an optional argument a required one) but I also couldn't find anything that doesn't already pass impersonated_credentials, since otherwise the pipeline doesn't actually work (e.g. checked [here](https://github.com/timeoutdigital/da-site-cleanup/blob/f9aed4d64b5df5194bf495f942eca3383d55a458/da_site_cleanup/etl_pipeline.py#L13) ; [here](https://github.com/timeoutdigital/da-cms-data-ingestion/blob/3d8e72a1664bbcccdce94516b8a91340f75262a3/da_cms_data_ingestion/etl_pipeline.py#L10) ; [here](https://github.com/timeoutdigital/da-survey-translation-temp/blob/0f02ce837291772edfeb144561c3e94976b506d5/src/da_survey_translation_temp/load_etl_pipeline.py#L6) ; [here](https://github.com/timeoutdigital/da-smaregi-to-datalake/blob/64e0307514727e72bc855212b0bbda23085ef550/src/da_smaregi_to_datalake/etl_pipeline.py#L12) ; [here](https://github.com/timeoutdigital/da-infolinks-to-datalake/blob/822d1593966260b1e132808bb0daec43e92098f4/src/da_infolinks_to_datalake/etl_pipeline.py#L10) )